### PR TITLE
feat(demo): Streamlit demo interface, context visualization, and documentation expansion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# RAG Pix Regulation — Environment Variables
+# Copy to .env and fill in your values:
+#
+#   cp .env.example .env
+
+# ── Weaviate ──────────────────────────────────────────────────────────────────
+WEAVIATE_HOST=localhost
+WEAVIATE_PORT=8080
+
+# ── Ollama ────────────────────────────────────────────────────────────────────
+OLLAMA_HOST=http://localhost:11434
+OLLAMA_MODEL=llama3.2:3b
+
+# ── Phoenix Observability (optional) ─────────────────────────────────────────
+# Leave empty to disable tracing.
+PHOENIX_HOST=localhost
+PHOENIX_PORT=6006
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+LOG_LEVEL=INFO

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install lightweight dependencies
         run: |
-          pip install pydantic pymupdf pytest
+          pip install pydantic pymupdf pytest transformers
 
       - name: Run unit tests (no model/Weaviate required)
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install ruff
+        run: pip install ruff
+      - name: Run ruff
+        run: ruff check .
+
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: Install lightweight dependencies
+        run: |
+          pip install pydantic pymupdf pytest
+
+      - name: Run unit tests (no model/Weaviate required)
+        run: |
+          pytest tests/test_text_cleaner.py \
+                 tests/test_metadata_extractor.py \
+                 tests/test_serializer.py \
+                 tests/test_structural_segmenter.py \
+                 tests/test_retrieval_metrics.py \
+                 tests/test_rag_evaluation.py \
+                 tests/test_dataset_loader.py \
+                 tests/test_rag_pipeline.py \
+                 -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,5 +43,5 @@ jobs:
                  tests/test_retrieval_metrics.py \
                  tests/test_rag_evaluation.py \
                  tests/test_dataset_loader.py \
-                 tests/test_rag_pipeline.py \
+                 tests/test_prompt_template.py \
                  -v

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,77 @@
+.PHONY: help test test-fast lint format weaviate phoenix ingest chunk index pipeline demo eval-retrieval eval-rag
+
+PYTHON := python
+PYTEST := pytest
+
+# ── Help ──────────────────────────────────────────────────────────────────────
+
+help:
+	@echo "RAG Pix Regulation — Development Commands"
+	@echo ""
+	@echo "  Setup"
+	@echo "    make weaviate          Start Weaviate via Docker Compose"
+	@echo "    make phoenix           Start Phoenix observability server"
+	@echo ""
+	@echo "  Pipeline"
+	@echo "    make ingest            PDF → corpus_pages.jsonl"
+	@echo "    make chunk             Pages → corpus_chunks.jsonl"
+	@echo "    make index             Chunks → embeddings → Weaviate"
+	@echo "    make pipeline          Full pipeline (ingest + chunk + init + index)"
+	@echo "    make demo              Launch Streamlit demo"
+	@echo ""
+	@echo "  Evaluation"
+	@echo "    make eval-retrieval    Evaluate retrieval metrics (Precision@K, Recall@K)"
+	@echo "    make eval-rag          Evaluate full RAG pipeline (requires Ollama)"
+	@echo ""
+	@echo "  Quality"
+	@echo "    make test              Run unit tests (excludes slow/integration tests)"
+	@echo "    make test-all          Run all tests"
+	@echo "    make lint              Check code style with ruff"
+	@echo "    make format            Auto-format code with ruff"
+
+# ── Infrastructure ────────────────────────────────────────────────────────────
+
+weaviate:
+	docker compose up -d
+
+phoenix:
+	$(PYTHON) -m phoenix.server.main serve
+
+# ── Data Pipeline ─────────────────────────────────────────────────────────────
+
+ingest:
+	$(PYTHON) scripts/run_ingestion.py
+
+chunk:
+	$(PYTHON) scripts/run_chunking.py
+
+index:
+	$(PYTHON) scripts/run_indexing.py
+
+pipeline:
+	$(PYTHON) scripts/run_pipeline.py
+
+demo:
+	streamlit run app/streamlit_app.py
+
+# ── Evaluation ────────────────────────────────────────────────────────────────
+
+eval-retrieval:
+	$(PYTHON) scripts/evaluate_retrieval.py
+
+eval-rag:
+	$(PYTHON) scripts/evaluate_rag.py
+
+# ── Quality ───────────────────────────────────────────────────────────────────
+
+test:
+	$(PYTEST) -m "not slow and not integration" -v
+
+test-all:
+	$(PYTEST) -v
+
+lint:
+	ruff check .
+
+format:
+	ruff format .

--- a/README.md
+++ b/README.md
@@ -40,6 +40,23 @@ The project is successful when:
 
 ---
 
+## Project Status
+
+| Phase | Description | Status |
+|-------|-------------|--------|
+| **1. Setup** | Repo, venv, dependencies | ✅ Complete |
+| **2. Ingestion** | PDF parsing, text extraction, metadata | ✅ Complete |
+| **3. Chunking** | Structural + token-based chunking | ✅ Complete |
+| **4. Embeddings** | BGE-M3 vectors, Weaviate indexing | ✅ Complete |
+| **5. Retrieval** | Semantic search, Recall@K, Precision@K | ✅ Complete |
+| **6. RAG Pipeline** | Prompt template, answer generation, citations | ✅ Complete |
+| **7. Evaluation & Observability** | Metrics, Phoenix tracing, evaluation runner | ✅ Complete |
+| **8. Demo & Publication** | Streamlit app, documentation | 🔄 In Progress |
+
+> **Note:** The full pipeline (phases 1–7) is functional. The Streamlit demo (`app/`) is under active development.
+
+---
+
 ## System Architecture
 
 ```
@@ -126,7 +143,7 @@ rag-pix-regulation/
 1. **Clone the repository**
 
    ```bash
-   git clone https://github.com/<your-username>/rag-pix-regulation.git
+   git clone https://github.com/brunoramosmartins/rag-pix-regulation.git
    cd rag-pix-regulation
    ```
 
@@ -260,7 +277,17 @@ python scripts/evaluate_rag.py
 
 ### Configuration
 
-Place configuration files in `config/`. Parameters such as `embedding_model`, `chunk_size`, `chunk_overlap`, `top_k`, and `llm_model` should be externalized (e.g., `config.yaml`) rather than hardcoded.
+Default parameters are defined in [`config/config.yaml`](config/config.yaml). Copy `.env.example` to `.env` for environment-specific overrides.
+
+Key parameters:
+
+| Parameter | Default | File |
+|-----------|---------|------|
+| `embedding_model` | `BAAI/bge-m3` | `config/config.yaml` |
+| `chunk_size` | `500` | `config/config.yaml` |
+| `chunk_overlap` | `50` | `config/config.yaml` |
+| `top_k` | `5` | `config/config.yaml` |
+| `llm_model` | `llama3.2:3b` | `config/config.yaml` |
 
 ---
 

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -1,5 +1,6 @@
 """Streamlit demo — Baseline vs RAG comparison for Pix regulation queries."""
 
+import concurrent.futures
 import html
 import sys
 from pathlib import Path
@@ -22,299 +23,343 @@ from src.demo import get_demo_health, run_baseline_query, run_rag_query
 
 # ── Page config ────────────────────────────────────────────────────────────────
 st.set_page_config(
-    page_title="RAG vs Baseline · Demo",
-    page_icon="⚡",
+    page_title="RAG vs Baseline · Pix Regulation",
+    page_icon="🏦",
     layout="wide",
     initial_sidebar_state="collapsed",
 )
 
-# ── Custom CSS ─────────────────────────────────────────────────────────────────
+# ── Custom CSS — light professional theme ─────────────────────────────────────
 st.markdown(
     """
 <style>
-  @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@300;400;500;600&display=swap');
+  @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@300;400;500;600;700&display=swap');
 
-  /* ── Reset & base ── */
+  /* ── Base ── */
   html, body, [class*="css"] {
     font-family: 'IBM Plex Sans', sans-serif;
-    background-color: #09090b;
-    color: #e4e4e7;
+    background-color: #f1f5f9;
+    color: #0f172a;
   }
-
-  .stApp { background-color: #09090b; }
-
-  /* ── Hide default streamlit chrome ── */
+  .stApp { background-color: #f1f5f9; }
   #MainMenu, footer, header { visibility: hidden; }
   .block-container { padding: 2rem 3rem 4rem; max-width: 1400px; }
 
-  /* ── Hero header ── */
+  /* ── Hero ── */
   .hero {
+    background: #ffffff;
+    border: 1px solid #e2e8f0;
+    border-radius: 16px;
     text-align: center;
-    padding: 3rem 0 2rem;
-    border-bottom: 1px solid #27272a;
-    margin-bottom: 2.5rem;
+    padding: 2.5rem 2rem 2rem;
+    margin-bottom: 1.75rem;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.06);
   }
   .hero-eyebrow {
     font-family: 'IBM Plex Mono', monospace;
-    font-size: 0.7rem;
+    font-size: 0.68rem;
     letter-spacing: 0.25em;
     text-transform: uppercase;
-    color: #71717a;
-    margin-bottom: 0.75rem;
+    color: #2563eb;
+    margin-bottom: 0.6rem;
+    font-weight: 500;
   }
   .hero-title {
-    font-size: 2.6rem;
-    font-weight: 600;
+    font-size: 2.2rem;
+    font-weight: 700;
     letter-spacing: -0.03em;
-    color: #fafafa;
+    color: #0f172a;
     margin: 0;
-    line-height: 1.1;
+    line-height: 1.15;
   }
-  .hero-title span.accent { color: #f59e0b; }
+  .hero-title .baseline-word { color: #dc2626; }
+  .hero-title .rag-word      { color: #16a34a; }
+  .hero-title .vs-word       { color: #94a3b8; font-weight: 300; }
   .hero-subtitle {
-    margin-top: 0.75rem;
-    font-size: 0.95rem;
-    color: #71717a;
-    font-weight: 300;
+    margin-top: 0.65rem;
+    font-size: 0.92rem;
+    color: #64748b;
+    font-weight: 400;
+  }
+  .hero-badges {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: center;
+    margin-top: 1rem;
+    flex-wrap: wrap;
+  }
+  .hero-badge {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.62rem;
+    padding: 0.2rem 0.65rem;
+    border-radius: 100px;
+    background: #f1f5f9;
+    border: 1px solid #cbd5e1;
+    color: #475569;
+    letter-spacing: 0.08em;
   }
 
   /* ── Query box ── */
   .query-wrapper {
-    background: #18181b;
-    border: 1px solid #3f3f46;
+    background: #ffffff;
+    border: 1px solid #e2e8f0;
     border-radius: 12px;
-    padding: 1.5rem 1.75rem;
-    margin-bottom: 2rem;
+    padding: 1.25rem 1.5rem;
+    margin-bottom: 1rem;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.04);
   }
   .query-label {
     font-family: 'IBM Plex Mono', monospace;
-    font-size: 0.65rem;
+    font-size: 0.63rem;
     letter-spacing: 0.2em;
     text-transform: uppercase;
-    color: #52525b;
-    margin-bottom: 0.5rem;
+    color: #94a3b8;
+    margin-bottom: 0.4rem;
+    font-weight: 500;
   }
   .stTextArea textarea {
-    background: #09090b !important;
-    border: 1px solid #3f3f46 !important;
+    background: #f8fafc !important;
+    border: 1px solid #cbd5e1 !important;
     border-radius: 8px !important;
-    color: #e4e4e7 !important;
+    color: #0f172a !important;
     font-family: 'IBM Plex Sans', sans-serif !important;
     font-size: 0.95rem !important;
     resize: none !important;
   }
   .stTextArea textarea:focus {
-    border-color: #f59e0b !important;
-    box-shadow: 0 0 0 2px rgba(245,158,11,0.15) !important;
+    border-color: #2563eb !important;
+    box-shadow: 0 0 0 3px rgba(37,99,235,0.1) !important;
+  }
+  .stTextArea textarea::placeholder { color: #94a3b8 !important; }
+
+  /* ── Selectbox ── */
+  .stSelectbox [data-baseweb="select"] > div {
+    background: #f8fafc !important;
+    border: 1px solid #cbd5e1 !important;
+    border-radius: 8px !important;
+    color: #475569 !important;
+    font-size: 0.88rem !important;
   }
 
   /* ── Run button ── */
   .stButton > button {
-    background: #f59e0b !important;
-    color: #09090b !important;
+    background: #2563eb !important;
+    color: #ffffff !important;
     border: none !important;
     border-radius: 8px !important;
     font-family: 'IBM Plex Sans', sans-serif !important;
     font-weight: 600 !important;
     font-size: 0.9rem !important;
-    padding: 0.6rem 2.2rem !important;
+    padding: 0.65rem 2rem !important;
     letter-spacing: 0.01em !important;
-    transition: all 0.15s !important;
+    transition: all 0.15s ease !important;
     width: 100% !important;
+    box-shadow: 0 1px 3px rgba(37,99,235,0.3) !important;
   }
   .stButton > button:hover {
-    background: #d97706 !important;
+    background: #1d4ed8 !important;
+    box-shadow: 0 4px 16px rgba(37,99,235,0.35) !important;
     transform: translateY(-1px) !important;
-    box-shadow: 0 4px 20px rgba(245,158,11,0.35) !important;
   }
   .stButton > button:active { transform: translateY(0) !important; }
 
   /* ── Column cards ── */
   .col-card {
-    background: #18181b;
+    background: #ffffff;
     border-radius: 12px;
     padding: 1.5rem;
     height: 100%;
-    border: 1px solid #27272a;
+    border: 1px solid #e2e8f0;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.05);
   }
-  .col-card.baseline { border-top: 3px solid #ef4444; }
-  .col-card.rag      { border-top: 3px solid #22c55e; }
+  .col-card.baseline { border-top: 4px solid #dc2626; }
+  .col-card.rag      { border-top: 4px solid #16a34a; }
 
   /* ── Column header ── */
   .col-header {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-bottom: 1.25rem;
-    padding-bottom: 1rem;
-    border-bottom: 1px solid #27272a;
+    margin-bottom: 1.1rem;
+    padding-bottom: 0.9rem;
+    border-bottom: 1px solid #f1f5f9;
   }
   .col-title {
     font-family: 'IBM Plex Mono', monospace;
-    font-size: 0.75rem;
-    letter-spacing: 0.15em;
+    font-size: 0.72rem;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
-    font-weight: 500;
+    font-weight: 600;
   }
-  .col-title.baseline { color: #ef4444; }
-  .col-title.rag      { color: #22c55e; }
+  .col-title.baseline { color: #dc2626; }
+  .col-title.rag      { color: #16a34a; }
 
   .badge {
     font-family: 'IBM Plex Mono', monospace;
-    font-size: 0.65rem;
-    padding: 0.2rem 0.6rem;
+    font-size: 0.6rem;
+    padding: 0.2rem 0.55rem;
     border-radius: 100px;
-    font-weight: 500;
-    letter-spacing: 0.1em;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
   }
-  .badge-red   { background: rgba(239,68,68,0.12);  color: #f87171; border: 1px solid rgba(239,68,68,0.25); }
-  .badge-green { background: rgba(34,197,94,0.12);  color: #4ade80; border: 1px solid rgba(34,197,94,0.25); }
+  .badge-red   { background: #fef2f2; color: #dc2626; border: 1px solid #fecaca; }
+  .badge-green { background: #f0fdf4; color: #16a34a; border: 1px solid #bbf7d0; }
 
   /* ── Response text ── */
   .response-text {
-    font-size: 0.92rem;
-    line-height: 1.75;
-    color: #d4d4d8;
+    font-size: 0.91rem;
+    line-height: 1.8;
+    color: #1e293b;
     min-height: 120px;
+    white-space: pre-wrap;
   }
 
   /* ── Meta row ── */
   .meta-row {
     display: flex;
-    gap: 1.25rem;
-    margin-top: 1.25rem;
-    padding-top: 1rem;
-    border-top: 1px solid #27272a;
+    gap: 1.5rem;
+    margin-top: 1.1rem;
+    padding-top: 0.9rem;
+    border-top: 1px solid #f1f5f9;
+    flex-wrap: wrap;
   }
-  .meta-item { display: flex; flex-direction: column; gap: 0.2rem; }
+  .meta-item { display: flex; flex-direction: column; gap: 0.15rem; }
   .meta-label {
     font-family: 'IBM Plex Mono', monospace;
-    font-size: 0.6rem;
+    font-size: 0.58rem;
     letter-spacing: 0.15em;
     text-transform: uppercase;
-    color: #52525b;
+    color: #94a3b8;
   }
-  .meta-value { font-size: 0.82rem; color: #a1a1aa; }
+  .meta-value { font-size: 0.82rem; color: #475569; font-weight: 500; }
 
   /* ── Chunk card ── */
   .chunk-card {
-    background: #09090b;
-    border: 1px solid #27272a;
-    border-left: 3px solid #3b82f6;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-left: 3px solid #2563eb;
     border-radius: 8px;
     padding: 0.85rem 1rem;
-    margin-bottom: 0.75rem;
+    margin-bottom: 0.65rem;
   }
   .chunk-header {
     display: flex;
-    gap: 0.5rem;
+    gap: 0.4rem;
     align-items: center;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.45rem;
     flex-wrap: wrap;
   }
   .chunk-tag {
     font-family: 'IBM Plex Mono', monospace;
     font-size: 0.6rem;
-    letter-spacing: 0.1em;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
-    background: #1e3a5f;
-    color: #93c5fd;
+    background: #dbeafe;
+    color: #1d4ed8;
     border-radius: 4px;
     padding: 0.15rem 0.5rem;
+    font-weight: 500;
   }
   .chunk-text {
-    font-size: 0.82rem;
-    color: #a1a1aa;
-    line-height: 1.6;
+    font-size: 0.83rem;
+    color: #475569;
+    line-height: 1.65;
   }
 
   /* ── Citations ── */
   .citation {
     display: inline-block;
     font-family: 'IBM Plex Mono', monospace;
-    font-size: 0.7rem;
-    background: rgba(34,197,94,0.08);
-    border: 1px solid rgba(34,197,94,0.2);
-    color: #4ade80;
+    font-size: 0.68rem;
+    background: #f0fdf4;
+    border: 1px solid #bbf7d0;
+    color: #15803d;
     border-radius: 4px;
     padding: 0.1rem 0.45rem;
     margin: 0.15rem 0.15rem 0.15rem 0;
+    font-weight: 500;
   }
 
-  /* ── Divider ── */
+  /* ── VS divider ── */
   .vs-divider {
     display: flex;
     align-items: center;
     justify-content: center;
     padding: 0 0.5rem;
-    color: #3f3f46;
+    color: #cbd5e1;
     font-family: 'IBM Plex Mono', monospace;
-    font-size: 0.75rem;
+    font-size: 0.7rem;
     letter-spacing: 0.1em;
+    font-weight: 500;
   }
 
-  /* ── Metric pills ── */
+  /* ── Metrics row ── */
   .metrics-row {
     display: flex;
-    gap: 1rem;
-    margin: 2rem 0 0.5rem;
+    gap: 0.85rem;
+    margin: 1.25rem 0 0.75rem;
     flex-wrap: wrap;
   }
   .metric-card {
     flex: 1;
-    min-width: 160px;
-    background: #18181b;
-    border: 1px solid #27272a;
+    min-width: 140px;
+    background: #ffffff;
+    border: 1px solid #e2e8f0;
     border-radius: 10px;
-    padding: 1rem 1.25rem;
+    padding: 0.9rem 1.1rem;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.04);
   }
   .metric-label {
     font-family: 'IBM Plex Mono', monospace;
-    font-size: 0.6rem;
-    letter-spacing: 0.18em;
+    font-size: 0.58rem;
+    letter-spacing: 0.16em;
     text-transform: uppercase;
-    color: #52525b;
-    margin-bottom: 0.4rem;
+    color: #94a3b8;
+    margin-bottom: 0.35rem;
   }
   .metric-value {
-    font-size: 1.5rem;
-    font-weight: 600;
-    color: #fafafa;
+    font-size: 1.55rem;
+    font-weight: 700;
+    color: #0f172a;
+    line-height: 1.1;
   }
-  .metric-delta {
-    font-size: 0.7rem;
-    color: #22c55e;
-    margin-top: 0.15rem;
-  }
+  .metric-delta { font-size: 0.68rem; color: #16a34a; margin-top: 0.2rem; }
+  .metric-delta.neutral { color: #64748b; }
 
   /* ── Expander ── */
   .streamlit-expanderHeader {
-    background: #18181b !important;
-    border: 1px solid #27272a !important;
+    background: #ffffff !important;
+    border: 1px solid #e2e8f0 !important;
     border-radius: 8px !important;
-    color: #a1a1aa !important;
-    font-size: 0.82rem !important;
+    color: #475569 !important;
+    font-size: 0.83rem !important;
   }
   .streamlit-expanderContent {
-    background: #18181b !important;
-    border: 1px solid #27272a !important;
+    background: #ffffff !important;
+    border: 1px solid #e2e8f0 !important;
     border-top: none !important;
     border-radius: 0 0 8px 8px !important;
   }
 
-  /* ── Spinner override ── */
-  .stSpinner > div { border-top-color: #f59e0b !important; }
+  /* ── Spinner ── */
+  .stSpinner > div { border-top-color: #2563eb !important; }
+
+  /* ── Alert boxes ── */
+  .stWarning { background: #fffbeb !important; border-color: #fde68a !important; }
+  .stInfo    { background: #eff6ff !important; border-color: #bfdbfe !important; }
+  .stError   { background: #fef2f2 !important; border-color: #fecaca !important; }
 
   /* ── Footer ── */
   .footer {
     text-align: center;
-    margin-top: 4rem;
-    padding-top: 1.5rem;
-    border-top: 1px solid #27272a;
+    margin-top: 3.5rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid #e2e8f0;
     font-family: 'IBM Plex Mono', monospace;
-    font-size: 0.65rem;
+    font-size: 0.62rem;
     letter-spacing: 0.1em;
-    color: #3f3f46;
+    color: #94a3b8;
     text-transform: uppercase;
   }
 </style>
@@ -325,58 +370,67 @@ st.markdown(
 # ── Health check ───────────────────────────────────────────────────────────────
 ready, msg = get_demo_health()
 if not ready:
-    st.warning(f"⚠️ **Dependencies not ready:** {msg}")
+    st.warning(f"⚠️ **Dependências não encontradas:** {msg}")
     st.info(
-        "Ensure Weaviate is running (`docker compose up -d`), the pipeline is indexed "
-        "(`python scripts/run_pipeline.py`), and Ollama is running (`ollama serve`)."
+        "Inicie o Weaviate (`docker compose up -d`), execute o pipeline "
+        "(`python scripts/run_pipeline.py`) e suba o Ollama (`ollama serve`)."
     )
 
 # ── Session state ──────────────────────────────────────────────────────────────
-if "result_baseline" not in st.session_state:
-    st.session_state.result_baseline = None
-if "result_rag" not in st.session_state:
-    st.session_state.result_rag = None
-if "query_used" not in st.session_state:
-    st.session_state.query_used = ""
+for key in ("result_baseline", "result_rag", "query_used"):
+    if key not in st.session_state:
+        st.session_state[key] = None
 
-# ── Example queries ───────────────────────────────────────────────────────────
+# ── Example queries ────────────────────────────────────────────────────────────
 EXAMPLE_QUERIES = [
     "Como funciona o registro de chave Pix?",
     "Quais são as regras de devolução por fraude?",
     "Como funciona a portabilidade de chave Pix?",
     "Quantas chaves Pix posso ter por conta?",
     "O que é o DICT no contexto do Pix?",
+    "Quais são os estados possíveis de uma notificação de infração no DICT?",
+    "Qual é o prazo para iniciar uma solicitação de devolução após fraude?",
 ]
 
-# ── Hero ──────────────────────────────────────────────────────────────────────
+# ── Hero ───────────────────────────────────────────────────────────────────────
 st.markdown(
     """
 <div class="hero">
-  <div class="hero-eyebrow">Retrieval-Augmented Generation · Demo</div>
-  <h1 class="hero-title">Baseline LLM <span class="accent">vs</span> RAG Pipeline</h1>
+  <div class="hero-eyebrow">🏦 Regulamentação Pix · Retrieval-Augmented Generation</div>
+  <h1 class="hero-title">
+    <span class="baseline-word">Baseline LLM</span>
+    <span class="vs-word"> vs </span>
+    <span class="rag-word">RAG Pipeline</span>
+  </h1>
   <p class="hero-subtitle">
-    Compare grounded, citation-backed answers against unaugmented generation &mdash;
-    Pix regulation knowledge base · Weaviate + Ollama
+    Compare respostas sem contexto (alucinações) versus respostas fundamentadas
+    em documentos regulatórios oficiais do BCB com citações verificáveis.
   </p>
+  <div class="hero-badges">
+    <span class="hero-badge">BAAI/bge-m3</span>
+    <span class="hero-badge">Weaviate</span>
+    <span class="hero-badge">Llama 3.2 · Ollama</span>
+    <span class="hero-badge">Phoenix Tracing</span>
+  </div>
 </div>
 """,
     unsafe_allow_html=True,
 )
 
-# ── Query input ─────────────────────────────────────────────────────────────────
+# ── Query input ────────────────────────────────────────────────────────────────
 st.markdown('<div class="query-wrapper">', unsafe_allow_html=True)
 st.markdown('<div class="query-label">Consulta</div>', unsafe_allow_html=True)
 
 query = st.text_area(
     label="",
     placeholder="Digite sua pergunta sobre regulamentação Pix…",
-    height=90,
+    height=85,
     key="query_input",
     label_visibility="collapsed",
 )
 
 st.markdown(
-    '<div class="query-label" style="margin-top:0.75rem;">Exemplos</div>',
+    '<div class="query-label" style="margin-top:0.65rem;">Ou selecione um exemplo</div>',
     unsafe_allow_html=True,
 )
 example = st.selectbox(
@@ -391,14 +445,17 @@ actual_query = query.strip() or (
 
 st.markdown("</div>", unsafe_allow_html=True)
 
-run_clicked = st.button("⚡  Executar comparação", use_container_width=True)
+run_clicked = st.button("🔍  Executar comparação", use_container_width=True)
 
-# ── Run pipeline ───────────────────────────────────────────────────────────────
+# ── Run pipeline — parallel execution ──────────────────────────────────────────
 if run_clicked and actual_query:
     try:
-        with st.spinner("Executando pipeline…"):
-            baseline = run_baseline_query(actual_query)
-            rag = run_rag_query(actual_query)
+        with st.spinner("Executando Baseline e RAG em paralelo…"):
+            with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+                future_baseline = executor.submit(run_baseline_query, actual_query)
+                future_rag = executor.submit(run_rag_query, actual_query)
+                baseline = future_baseline.result()
+                rag = future_rag.result()
         st.session_state.result_baseline = baseline
         st.session_state.result_rag = rag
         st.session_state.query_used = actual_query
@@ -408,160 +465,159 @@ if run_clicked and actual_query:
 elif run_clicked:
     st.warning("Digite uma pergunta ou selecione um exemplo antes de executar.")
 
-# ── Results ───────────────────────────────────────────────────────────────────
+# ── Results ────────────────────────────────────────────────────────────────────
 if st.session_state.result_baseline and st.session_state.result_rag:
     bl = st.session_state.result_baseline
     rag = st.session_state.result_rag
 
-    # ── Escape user content for HTML ─────────────────────────────────────────────
     def _esc(s: str) -> str:
         return html.escape(str(s)) if s else ""
 
-    bl_ans, rag_ans = _esc(bl["answer"]), _esc(rag["answer"])
-    bl_mod, rag_mod = _esc(bl["model"]), _esc(rag["model"])
+    bl_ans = _esc(bl["answer"])
+    rag_ans = _esc(rag["answer"])
 
-    # ── Top metrics row ────────────────────────────────────────────────────────
+    # ── Metrics row ────────────────────────────────────────────────────────────
+    latency_diff = rag["latency_ms"] - bl["latency_ms"]
+    latency_delta_color = "#64748b"  # neutral — RAG always slower due to retrieval
     st.markdown(
         f"""
-    <div class="metrics-row">
-      <div class="metric-card">
-        <div class="metric-label">Fontes recuperadas</div>
-        <div class="metric-value">{rag["sources"]}</div>
-        <div class="metric-delta">↑ vs 0 (baseline)</div>
-      </div>
-      <div class="metric-card">
-        <div class="metric-label">Latência baseline</div>
-        <div class="metric-value">{bl["latency_ms"]} ms</div>
-        <div class="metric-delta" style="color:#a1a1aa;">sem retrieval</div>
-      </div>
-      <div class="metric-card">
-        <div class="metric-label">Latência RAG</div>
-        <div class="metric-value">{rag["latency_ms"]} ms</div>
-        <div class="metric-delta">embed + search + gen</div>
-      </div>
-      <div class="metric-card">
-        <div class="metric-label">Citações</div>
-        <div class="metric-value">{len(rag.get("citations", []))}</div>
-        <div class="metric-delta">documentos rastreáveis</div>
-      </div>
-    </div>
-    """,
+<div class="metrics-row">
+  <div class="metric-card">
+    <div class="metric-label">Fontes recuperadas</div>
+    <div class="metric-value">{rag["sources"]}</div>
+    <div class="metric-delta">↑ vs 0 no baseline</div>
+  </div>
+  <div class="metric-card">
+    <div class="metric-label">Citações</div>
+    <div class="metric-value">{len(rag.get("citations", []))}</div>
+    <div class="metric-delta">documentos rastreáveis</div>
+  </div>
+  <div class="metric-card">
+    <div class="metric-label">Latência Baseline</div>
+    <div class="metric-value">{bl["latency_ms"]} ms</div>
+    <div class="metric-delta neutral">sem retrieval</div>
+  </div>
+  <div class="metric-card">
+    <div class="metric-label">Latência RAG</div>
+    <div class="metric-value">{rag["latency_ms"]} ms</div>
+    <div class="metric-delta neutral">embed + busca + geração</div>
+  </div>
+</div>
+""",
         unsafe_allow_html=True,
     )
 
     st.markdown("<br>", unsafe_allow_html=True)
 
-    # ── Side-by-side columns ───────────────────────────────────────────────────
+    # ── Side-by-side ──────────────────────────────────────────────────────────
     col_bl, col_vs, col_rag = st.columns([10, 1, 10])
 
-    # ── Baseline ──────────────────────────────────────────────────────────────
     with col_bl:
         st.markdown(
             f"""
-        <div class="col-card baseline">
-          <div class="col-header">
-            <span class="col-title baseline">⬡ Baseline LLM</span>
-            <span class="badge badge-red">SEM RETRIEVAL</span>
-          </div>
-          <div class="response-text">{bl_ans}</div>
-          <div class="meta-row">
-            <div class="meta-item">
-              <span class="meta-label">Modelo</span>
-              <span class="meta-value">{bl_mod}</span>
-            </div>
-            <div class="meta-item">
-              <span class="meta-label">Fontes</span>
-              <span class="meta-value">{bl["sources"]} documentos</span>
-            </div>
-            <div class="meta-item">
-              <span class="meta-label">Latência</span>
-              <span class="meta-value">{bl["latency_ms"]} ms</span>
-            </div>
-          </div>
-        </div>
-        """,
+<div class="col-card baseline">
+  <div class="col-header">
+    <span class="col-title baseline">⚠ Baseline LLM</span>
+    <span class="badge badge-red">Sem Retrieval</span>
+  </div>
+  <div class="response-text">{bl_ans}</div>
+  <div class="meta-row">
+    <div class="meta-item">
+      <span class="meta-label">Modelo</span>
+      <span class="meta-value">{_esc(bl["model"])}</span>
+    </div>
+    <div class="meta-item">
+      <span class="meta-label">Fontes</span>
+      <span class="meta-value">0 documentos</span>
+    </div>
+    <div class="meta-item">
+      <span class="meta-label">Latência</span>
+      <span class="meta-value">{bl["latency_ms"]} ms</span>
+    </div>
+  </div>
+</div>
+""",
             unsafe_allow_html=True,
         )
 
-    # ── VS divider ──────────────────────────────────────────────────────────────
     with col_vs:
         st.markdown(
             '<div class="vs-divider" style="height:100%;display:flex;align-items:center;">VS</div>',
             unsafe_allow_html=True,
         )
 
-    # ── RAG ────────────────────────────────────────────────────────────────────
     with col_rag:
         citations_html = "".join(
-            f'<span class="citation">{_esc(c)}</span>' for c in rag.get("citations", [])
+            f'<span class="citation">{_esc(c)}</span>'
+            for c in rag.get("citations", [])
         )
         st.markdown(
             f"""
-        <div class="col-card rag">
-          <div class="col-header">
-            <span class="col-title rag">◈ RAG Pipeline</span>
-            <span class="badge badge-green">COM RETRIEVAL</span>
-          </div>
-          <div class="response-text">{rag_ans}</div>
-          <div style="margin-top:0.85rem;">
-            <div class="meta-label" style="margin-bottom:0.4rem;">Citações</div>
-            {citations_html}
-          </div>
-          <div class="meta-row">
-            <div class="meta-item">
-              <span class="meta-label">Modelo</span>
-              <span class="meta-value">{rag_mod}</span>
-            </div>
-            <div class="meta-item">
-              <span class="meta-label">Fontes</span>
-              <span class="meta-value">{rag["sources"]} chunks</span>
-            </div>
-            <div class="meta-item">
-              <span class="meta-label">Latência</span>
-              <span class="meta-value">{rag["latency_ms"]} ms</span>
-            </div>
-          </div>
-        </div>
-        """,
+<div class="col-card rag">
+  <div class="col-header">
+    <span class="col-title rag">✓ RAG Pipeline</span>
+    <span class="badge badge-green">Com Retrieval</span>
+  </div>
+  <div class="response-text">{rag_ans}</div>
+  <div style="margin-top:0.8rem;">
+    <div class="meta-label" style="margin-bottom:0.35rem;">Citações</div>
+    {citations_html if citations_html else '<span style="color:#94a3b8;font-size:0.82rem;">—</span>'}
+  </div>
+  <div class="meta-row">
+    <div class="meta-item">
+      <span class="meta-label">Modelo</span>
+      <span class="meta-value">{_esc(rag["model"])}</span>
+    </div>
+    <div class="meta-item">
+      <span class="meta-label">Fontes</span>
+      <span class="meta-value">{rag["sources"]} chunks</span>
+    </div>
+    <div class="meta-item">
+      <span class="meta-label">Latência</span>
+      <span class="meta-value">{rag["latency_ms"]} ms</span>
+    </div>
+  </div>
+</div>
+""",
             unsafe_allow_html=True,
         )
 
-    # ── Retrieved context ──────────────────────────────────────────────────────
+    # ── Retrieved chunks ───────────────────────────────────────────────────────
     chunks = rag.get("chunks", [])
     if chunks:
         st.markdown("<br>", unsafe_allow_html=True)
         with st.expander(
-            f"🔍  Contexto recuperado — {len(chunks)} chunks", expanded=False
+            f"📄  Contexto recuperado — {len(chunks)} chunks indexados", expanded=False
         ):
             for i, chunk in enumerate(chunks):
                 score = chunk.get("score", 0)
-                score_color = (
-                    "#22c55e"
-                    if score >= 0.94
-                    else "#f59e0b"
-                    if score >= 0.88
-                    else "#ef4444"
-                )
-                doc_id = _esc(chunk.get("document_id", "—"))
+                if score >= 0.94:
+                    score_color = "#16a34a"
+                elif score >= 0.88:
+                    score_color = "#d97706"
+                else:
+                    score_color = "#dc2626"
+
+                doc_label = _esc(chunk.get("document_alias") or chunk.get("document_id", "—"))
                 page = chunk.get("page", "—")
                 section = _esc(chunk.get("section", "—"))
                 text = _esc(chunk.get("text", ""))
                 st.markdown(
                     f"""
-                <div class="chunk-card">
-                  <div class="chunk-header">
-                    <span class="chunk-tag">#{i + 1}</span>
-                    <span class="chunk-tag">{doc_id}</span>
-                    <span class="chunk-tag">p. {page}</span>
-                    <span class="chunk-tag">{section}</span>
-                    <span style="margin-left:auto;font-family:'IBM Plex Mono',monospace;
-                                 font-size:0.7rem;color:{score_color};">
-                      score {score:.3f}
-                    </span>
-                  </div>
-                  <div class="chunk-text">{text}</div>
-                </div>
-                """,
+<div class="chunk-card">
+  <div class="chunk-header">
+    <span class="chunk-tag">#{i + 1}</span>
+    <span class="chunk-tag">{doc_label}</span>
+    <span class="chunk-tag">p. {page}</span>
+    <span class="chunk-tag">{section}</span>
+    <span style="margin-left:auto;font-family:'IBM Plex Mono',monospace;
+                 font-size:0.68rem;color:{score_color};font-weight:600;">
+      {score:.3f}
+    </span>
+  </div>
+  <div class="chunk-text">{text}</div>
+</div>
+""",
                     unsafe_allow_html=True,
                 )
 
@@ -569,17 +625,17 @@ if st.session_state.result_baseline and st.session_state.result_rag:
 elif not run_clicked:
     st.markdown(
         """
-    <div style="text-align:center;padding:4rem 0;color:#3f3f46;">
-      <div style="font-size:2.5rem;margin-bottom:1rem;">⚡</div>
-      <div style="font-family:'IBM Plex Mono',monospace;font-size:0.75rem;
-                  letter-spacing:0.2em;text-transform:uppercase;">
-        Aguardando consulta
-      </div>
-      <div style="font-size:0.85rem;margin-top:0.5rem;color:#27272a;">
-        Digite uma pergunta acima ou selecione um exemplo e clique em Executar
-      </div>
-    </div>
-    """,
+<div style="text-align:center;padding:4rem 0;color:#cbd5e1;">
+  <div style="font-size:3rem;margin-bottom:0.75rem;">🏦</div>
+  <div style="font-family:'IBM Plex Mono',monospace;font-size:0.72rem;
+              letter-spacing:0.22em;text-transform:uppercase;color:#94a3b8;">
+    Aguardando consulta
+  </div>
+  <div style="font-size:0.85rem;margin-top:0.5rem;color:#cbd5e1;">
+    Selecione um exemplo ou escreva uma pergunta e clique em <strong>Executar comparação</strong>
+  </div>
+</div>
+""",
         unsafe_allow_html=True,
     )
 
@@ -587,8 +643,8 @@ elif not run_clicked:
 st.markdown(
     """
 <div class="footer">
-  RAG Demo · Weaviate · Ollama · Streamlit &nbsp;|&nbsp;
-  Knowledge base: Regulamentação Pix BCB
+  RAG Pix Regulation &nbsp;·&nbsp; Weaviate &nbsp;·&nbsp; Ollama &nbsp;·&nbsp; Streamlit
+  &nbsp;|&nbsp; Base de conhecimento: Regulamentação Pix BCB · MED 2.0
 </div>
 """,
     unsafe_allow_html=True,

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,0 +1,34 @@
+# RAG Pix Regulation — Default Configuration
+# Override individual values via environment variables (see .env.example).
+
+embeddings:
+  model: "BAAI/bge-m3"
+  batch_size: 32
+  dimensions: 1024
+
+chunking:
+  chunk_size: 500        # tokens per chunk
+  chunk_overlap: 50      # overlapping tokens between consecutive chunks
+
+retrieval:
+  top_k: 5              # number of chunks to retrieve per query
+  collection: "PixRegulationChunks"
+
+llm:
+  model: "llama3.2:3b"
+  temperature: 0
+  top_p: 1.0
+
+rag:
+  max_context_tokens: 4096
+
+weaviate:
+  host: "localhost"
+  port: 8080
+
+ollama:
+  host: "http://localhost:11434"
+
+phoenix:
+  host: "localhost"
+  port: 6006

--- a/config/document_aliases.yaml
+++ b/config/document_aliases.yaml
@@ -1,0 +1,17 @@
+# Document display aliases
+# Maps document_id (filename stem, lowercase) → human-readable name shown in citations and UI.
+# document_id is generated from the PDF filename: stem.lower().replace(" ", "_")
+
+# ── Current names (post-rename) ───────────────────────────────────────────────
+manual_operacional_dict: "Manual Operacional do DICT (MED 2.0)"
+manual_tempos_pix: "Manual de Tempos do Pix v7.0"
+manual_interfaces_comunicacao: "Manual das Interfaces de Comunicação v1.12"
+manual_resolucao_disputas: "Manual de Resolução de Disputas v5.0"
+manual_fluxos_pix: "Manual de Fluxos do Pix v2.1"
+manual_iniciacao_pix: "Manual de Padrões para Iniciação do Pix v2.9.0"
+manual_marca_pix: "Manual de Uso da Marca Pix v1.6"
+
+# ── Legacy names (pre-rename) — remove after full re-index ───────────────────
+x_manualoperacionaldodict: "Manual Operacional do DICT (MED 2.0)"
+ix_manualdtempsdopix: "Manual de Tempos do Pix v7.0"
+xi_manual_de_resolucao_de_disputa: "Manual de Resolução de Disputas v5.0"

--- a/data/SOURCES.md
+++ b/data/SOURCES.md
@@ -1,9 +1,33 @@
-# Regulatory Corpus — Source Documentation
+# Corpus — Source Documentation
 
-Source URLs and download dates for traceability and reproducibility.
+Source documents indexed in the RAG knowledge base. All are official publications of the Banco Central do Brasil (BCB).
 
-| Document | Filename | Source URL | Download Date |
-|----------|----------|------------|---------------|
-| Manual Operacional do Diretório de Identificadores de Contas Transacionais (DICT) | X_ManualOperacionaldoDICT.pdf | https://www.bcb.gov.br/content/estabilidadefinanceira/pix/Regulamento_Pix/X_ManualOperacionaldoDICT.pdf | 2026-03-07 |
+| Alias | Filename | Version | Source URL |
+|-------|----------|---------|------------|
+| Manual Operacional do DICT (MED 2.0) | `manual_operacional_dict.pdf` | MED 2.0 | [bcb.gov.br](https://www.bcb.gov.br/content/estabilidadefinanceira/pix/Regulamento_Pix/X_ManualOperacionaldoDICT.pdf) |
+| Manual de Tempos do Pix v7.0 | `manual_tempos_pix.pdf` | v7.0 | [bcb.gov.br](https://www.bcb.gov.br/content/estabilidadefinanceira/pix/Regulamento_Pix/IX_ManualdeTemposdoPix.pdf) |
+| Manual das Interfaces de Comunicação v1.12 | `manual_interfaces_comunicacao.pdf` | v1.12 | [bcb.gov.br](https://www.bcb.gov.br/content/estabilidadefinanceira/pix/Regulamento_Pix/Manual_das_Interfaces_de_Comunicacao.pdf) |
+| Manual de Resolução de Disputas v5.0 | `manual_resolucao_disputas.pdf` | v5.0 | [bcb.gov.br](https://www.bcb.gov.br/content/estabilidadefinanceira/pix/Regulamento_Pix/XI_Manual_de_resolucao_de_disputa.pdf) |
+| Manual de Fluxos do Pix v2.1 | `manual_fluxos_pix.pdf` | v2.1 | [bcb.gov.br](https://www.bcb.gov.br/content/estabilidadefinanceira/pix/Regulamento_Pix/Manual_Fluxos_Efetivacao_Pix.pdf) |
+| Manual de Padrões para Iniciação do Pix v2.9.0 | `manual_iniciacao_pix.pdf` | v2.9.0 | [bcb.gov.br](https://www.bcb.gov.br/content/estabilidadefinanceira/pix/Regulamento_Pix/Manual_Padroes_Iniciacao_Pix.pdf) |
+| Manual de Uso da Marca Pix v1.6 | `manual_marca_pix.pdf` | v1.6 | [bcb.gov.br](https://www.bcb.gov.br/content/estabilidadefinanceira/pix/marca_pix/Manual_de_Uso_da_Marca_Pix.pdf) |
 
 ---
+
+## Not Indexed
+
+| File | Reason |
+|------|--------|
+| `pix-normas` | HTML document — requires a dedicated HTML parser. Not processed by the PDF ingestion pipeline. |
+
+---
+
+## Re-indexing After Adding Documents
+
+After adding new PDFs to `data/raw/`, rebuild the full pipeline:
+
+```bash
+make pipeline   # or: python scripts/run_pipeline.py
+```
+
+This clears and rebuilds the Weaviate collection with all documents.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "50051:50051"
     environment:
       QUERY_DEFAULTS_LIMIT: 25
-      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: "true"
+      AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: "true"  # DEV ONLY — disable in production
       PERSISTENCE_DATA_PATH: "/var/lib/weaviate"
       DEFAULT_VECTORIZER_MODULE: "none"
       CLUSTER_HOSTNAME: "node1"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,39 +6,151 @@ This document describes the modular architecture for the RAG system that serves 
 
 ## System Flow
 
-```
-Regulatory PDFs (BCB, MED 2.0)
-            ↓
-       Parsing
-            ↓
-       Chunking
-            ↓
-      Embeddings
-            ↓
-Vector Database (Weaviate)
-            ↓
-       Retriever
-            ↓
-    Prompt Builder
-            ↓
-           LLM
-            ↓
-  Response + Citations
-            ↓
-Evaluation + Observability (Phoenix)
+```mermaid
+flowchart TD
+    A[Regulatory PDFs<br/>BCB · MED 2.0] --> B[Ingestion<br/>pdf_loader · text_cleaner · metadata_extractor]
+    B --> C[corpus_pages.jsonl]
+    C --> D[Chunking<br/>structural_segmenter → token_chunker]
+    D --> E[corpus_chunks.jsonl]
+    E --> F[Embeddings<br/>BAAI/bge-m3]
+    F --> G[Weaviate<br/>Vector Database]
+
+    H[User Query] --> I[Query Embedding<br/>BAAI/bge-m3]
+    I --> J[Vector Search<br/>ANN · top-k]
+    G --> J
+    J --> K[Context Builder<br/>token budget · citation markers]
+    K --> L[Prompt Template<br/>system instruction + context + query]
+    L --> M[LLM<br/>Llama-3.2-3B via Ollama]
+    M --> N[Answer + Citations]
+
+    N --> O[Evaluation<br/>Precision@K · Recall@K · Grounding]
+    N --> P[Phoenix Tracing<br/>OpenTelemetry spans]
 ```
 
 ---
 
 ## Tech Stack
 
-| Layer | Technology |
-|-------|-------------|
-| **LLM** | meta-llama/Llama-3.2-3B-Instruct |
-| **Embeddings** | BAAI/bge-m3 (multilingual, Portuguese) |
-| **Vector DB** | Weaviate (embedded) |
-| **Observability** | Phoenix + OpenTelemetry |
-| **Application** | Streamlit |
+| Layer | Technology | Rationale |
+|-------|------------|-----------|
+| **LLM** | meta-llama/Llama-3.2-3B-Instruct via Ollama | Local execution, no API cost, deterministic (temp=0) |
+| **Embeddings** | BAAI/bge-m3 | State-of-the-art multilingual model; strong Portuguese performance; 1024-dim dense vectors |
+| **Vector DB** | Weaviate | Production-grade, cosine similarity native support, schema validation, batch insert API |
+| **Observability** | Phoenix + OpenTelemetry | RAG-native span kinds (retriever, chain, LLM), no vendor lock-in |
+| **Application** | Streamlit | Rapid prototyping, side-by-side baseline vs. RAG comparison |
+| **Serialization** | JSONL + Pydantic v2 | Line-delimited streaming, schema enforcement, zero serialization overhead |
+
+---
+
+## Architecture Decision Records
+
+### ADR-01: BGE-M3 over OpenAI Embeddings
+
+**Context:** The corpus is in Portuguese (legal/technical register). Embedding quality for this domain is critical.
+
+**Decision:** Use `BAAI/bge-m3` (1024-dim, multilingual) instead of OpenAI's `text-embedding-ada-002` or `text-embedding-3-small`.
+
+**Rationale:**
+- BGE-M3 achieves state-of-the-art results on Portuguese MTEB benchmarks
+- Runs locally with no API cost or rate limits
+- Deterministic: same input always produces the same vector
+- 1024 dimensions provide rich semantic representation for regulatory text
+
+**Trade-off:** Requires ~1.3 GB local model download on first use. Acceptable for a portfolio project; mitigated by model caching.
+
+---
+
+### ADR-02: Structural Segmentation Before Token Chunking
+
+**Context:** Raw PDF pages don't respect semantic boundaries. Naive fixed-size chunking splits articles mid-sentence.
+
+**Decision:** Apply two-stage chunking:
+1. **Structural segmentation** — split pages at article/paragraph markers (`Art.`, `§`, numbered sections)
+2. **Token chunking** — apply sliding window (500 tokens, 50 overlap) within each segment
+
+**Rationale:**
+- Regulatory text has natural semantic units (articles, paragraphs, sections)
+- Structural segmentation preserves legal coherence — a chunk about "Art. 5º" doesn't bleed into "Art. 6º"
+- Token chunking ensures each chunk fits the model's context window
+- Overlap retains continuity across chunk boundaries
+
+**Trade-off:** Two-pass pipeline is more complex than naive chunking. Complexity is bounded and well-tested.
+
+---
+
+### ADR-03: Weaviate over Chroma or FAISS
+
+**Context:** Need a vector database for embedding storage and ANN retrieval.
+
+**Decision:** Use Weaviate (Docker, local) instead of Chroma (embedded) or FAISS (in-memory).
+
+**Rationale:**
+- Weaviate persists data across runs without reimporting; Chroma is embedded (reset risk); FAISS is in-memory only
+- Schema validation ensures consistent property types at insert time
+- Batch import API enables efficient bulk indexing
+- Docker Compose deployment mirrors production patterns better than an embedded DB
+
+**Trade-off:** Requires Docker. Mitigated by providing `docker-compose.yml` with a single command start.
+
+---
+
+### ADR-04: Ollama for Local LLM Inference
+
+**Context:** Need a text-generation LLM for the RAG answer step without API keys or costs.
+
+**Decision:** Use Ollama serving `llama3.2:3b` locally.
+
+**Rationale:**
+- Zero API cost for development and evaluation
+- Deterministic inference with `temperature=0, top_p=1.0`
+- Model abstracted behind `LLMClient` interface — trivial to swap for OpenAI, Anthropic, or any other provider
+- 3B parameter model runs on CPU; fits portfolio constraints
+
+**Trade-off:** Quality ceiling lower than GPT-4 class models. Acceptable for a retrieval-grounded system where the LLM role is primarily formatting and synthesis.
+
+---
+
+## Module Responsibilities
+
+| Module | Key Files | Inputs | Outputs |
+|--------|-----------|--------|---------|
+| **ingestion** | `pdf_loader`, `text_cleaner`, `metadata_extractor`, `serializer` | PDF files | `corpus_pages.jsonl` |
+| **chunking** | `structural_segmenter`, `token_chunker`, `serializer`, `loader` | `corpus_pages.jsonl` | `corpus_chunks.jsonl` |
+| **embeddings** | `embedding_generator`, `validation` | `corpus_chunks.jsonl` | `(Chunk, vector)` pairs |
+| **vectorstore** | `weaviate_client`, `indexer` | `(Chunk, vector)` pairs | Weaviate collection |
+| **retrieval** | `query_embedding`, `vector_search`, `retriever` | User query string | `list[RetrievalResult]` |
+| **rag** | `context_builder`, `prompt_template`, `rag_pipeline` | `list[RetrievalResult]` + LLM | `RAGResponse` with citations |
+| **evaluation** | `dataset_loader`, `retrieval_metrics`, `rag_evaluation`, `evaluation_runner` | Dataset + RAG fn | JSON evaluation report |
+| **observability** | `tracing` | Span names + attributes | OpenTelemetry spans → Phoenix |
+| **demo** | `demo_service` | Query string | Baseline + RAG result dicts |
+
+---
+
+## Inter-Module Data Flow
+
+```
+PDF files
+  → [ingestion] → Page (Pydantic model)
+  → [serializer] → JSONL line (corpus_pages.jsonl)
+
+corpus_pages.jsonl
+  → [chunking.structural_segmenter] → StructuralSegment (Pydantic model)
+  → [chunking.token_chunker] → Chunk (Pydantic model)
+  → [chunking.serializer] → JSONL line (corpus_chunks.jsonl)
+
+corpus_chunks.jsonl
+  → [embeddings.embedding_generator] → (Chunk, list[float])
+  → [vectorstore.indexer] → Weaviate object
+
+User query: str
+  → [retrieval.query_embedding] → list[float]  (1024-dim)
+  → [retrieval.vector_search] → list[dict]
+  → [retrieval.retriever] → list[RetrievalResult]
+  → [rag.context_builder] → str  (token-budgeted context)
+  → [rag.prompt_template] → str  (final prompt)
+  → [llm.baseline_llm] → (answer: str, usage: LLMUsage)
+  → [rag.rag_pipeline] → RAGResponse
+```
 
 ---
 
@@ -48,47 +160,36 @@ Evaluation + Observability (Phoenix)
 rag-pix-regulation/
 ├── data/
 │   ├── raw/              # Original regulatory documents (PDFs)
+│   ├── evaluation/       # Retrieval evaluation dataset (ground truth)
 │   └── processed/        # Chunked documents, embeddings
 ├── src/
 │   ├── ingestion/        # Document loading and PDF parsing
 │   ├── chunking/         # Document splitting strategies
 │   ├── embeddings/       # Vector representations
+│   ├── vectorstore/      # Weaviate client and indexing
 │   ├── retrieval/        # Similarity search
 │   ├── rag/              # RAG pipeline orchestration
 │   ├── evaluation/       # Retrieval quality, grounding, hallucination metrics
-│   └── observability/    # Phoenix tracing and monitoring
-├── scripts/              # Utility and pipeline scripts
-├── notebooks/            # Experimentation and analysis
+│   ├── observability/    # Phoenix tracing and monitoring
+│   ├── demo/             # Service layer for Streamlit UI
+│   └── utils/            # System health checks
+├── scripts/              # Runnable pipeline and validation scripts
 ├── tests/                # Unit and integration tests
 ├── config/               # Configuration (YAML, env templates)
-├── docs/                 # Project documentation
+├── docs/                 # Architecture and design docs
 └── app/                  # Streamlit application
 ```
 
 ---
 
-## Module Responsibilities
-
-| Module | Purpose |
-|--------|---------|
-| **ingestion** | Load documents from sources, parse PDFs, extract text and metadata |
-| **chunking** | Split documents into retrieval-optimized chunks with overlap |
-| **embeddings** | Generate vector representations for semantic search |
-| **retrieval** | Similarity search, ranking, top-k retrieval |
-| **rag** | Orchestrate retrieval + generation, prompt building, citation injection |
-| **evaluation** | Measure Recall@K, Precision@K, grounding, hallucination rates |
-| **observability** | Phoenix integration for tracing, token usage, context inspection |
-
----
-
 ## Design Principles
 
-- **Separation of concerns**: Each module has a single responsibility
-- **Reproducibility**: Config-driven, versioned data and models
-- **Extensibility**: Modular design allows swapping components (embedding models, vector stores, LLMs)
-- **Testability**: Unit tests per module, integration tests for pipelines
-- **Traceability**: Responses cite source documents for audit and compliance
-- **Observability**: Phoenix tracing for debugging and performance analysis
+- **Separation of concerns** — Each module has a single responsibility with no circular dependencies
+- **Reproducibility** — Config-driven parameters, versioned data (JSONL), deterministic embeddings
+- **Extensibility** — `LLMClient` abstract interface allows swapping inference backends; vector store abstracted behind `weaviate_client`
+- **Testability** — Unit tests per module; integration tests skip gracefully when services are unavailable
+- **Traceability** — Every answer cites source document and page; chunk IDs are deterministic (`{doc_id}_p{page}_s{segment}_c{chunk}`)
+- **Observability** — Phoenix tracing wraps all RAG spans (retriever → context → prompt → LLM) with input/output attributes
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,20 @@
+[project]
+name = "rag-pix-regulation"
+version = "0.7.0"
+description = "RAG system for querying Brazilian Pix regulatory documentation"
+requires-python = ">=3.10"
+authors = [{ name = "Bruno Ramos Martins" }]
+readme = "README.md"
+license = { text = "MIT" }
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]
+markers = [
+    "slow: tests that download large models (~1.3 GB) or take significant time",
+    "integration: tests that require external services (Weaviate, Ollama)",
+]
+
 [tool.ruff]
 line-length = 88
 target-version = "py310"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ requires-python = ">=3.10"
 authors = [{ name = "Bruno Ramos Martins" }]
 readme = "README.md"
 license = { text = "MIT" }
+dependencies = [
+    "transformers>=4.30.0",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -25,3 +28,5 @@ exclude = ["RAG_DeepLearningAI"]
 "app/streamlit_app.py" = ["E402"]
 "scripts/evaluate_rag.py" = ["E402"]
 "scripts/evaluate_retrieval.py" = ["E402"]
+"scripts/demo_rag.py" = ["E402"]
+"scripts/compare_rag_vs_llm.py" = ["E402"]

--- a/reports/evaluation_report.json
+++ b/reports/evaluation_report.json
@@ -1,0 +1,95 @@
+{
+  "retrieval": {
+    "precision@5": 0.34,
+    "recall@5": 1.5,
+    "n_queries": 10
+  },
+  "rag": {
+    "citation_coverage": 1.0,
+    "groundedness_avg": 1.0,
+    "hallucination_rate": 0.0,
+    "n_queries": 10
+  },
+  "per_query": [
+    {
+      "query_id": "eq1",
+      "precision_at_k": 0.4,
+      "recall_at_k": 2.0,
+      "citation_coverage": 1.0,
+      "groundedness_score": 1.0,
+      "hallucination_detected": false
+    },
+    {
+      "query_id": "eq2",
+      "precision_at_k": 0.8,
+      "recall_at_k": 2.0,
+      "citation_coverage": 1.0,
+      "groundedness_score": 1.0,
+      "hallucination_detected": false
+    },
+    {
+      "query_id": "eq3",
+      "precision_at_k": 0.0,
+      "recall_at_k": 0.0,
+      "citation_coverage": 1.0,
+      "groundedness_score": 1.0,
+      "hallucination_detected": false
+    },
+    {
+      "query_id": "eq4",
+      "precision_at_k": 0.4,
+      "recall_at_k": 2.0,
+      "citation_coverage": 1.0,
+      "groundedness_score": 1.0,
+      "hallucination_detected": false
+    },
+    {
+      "query_id": "eq5",
+      "precision_at_k": 0.4,
+      "recall_at_k": 2.0,
+      "citation_coverage": 1.0,
+      "groundedness_score": 1.0,
+      "hallucination_detected": false
+    },
+    {
+      "query_id": "eq6",
+      "precision_at_k": 0.8,
+      "recall_at_k": 4.0,
+      "citation_coverage": 1.0,
+      "groundedness_score": 1.0,
+      "hallucination_detected": false
+    },
+    {
+      "query_id": "eq7",
+      "precision_at_k": 0.6,
+      "recall_at_k": 3.0,
+      "citation_coverage": 1.0,
+      "groundedness_score": 1.0,
+      "hallucination_detected": false
+    },
+    {
+      "query_id": "eq8",
+      "precision_at_k": 0.0,
+      "recall_at_k": 0.0,
+      "citation_coverage": 1.0,
+      "groundedness_score": 1.0,
+      "hallucination_detected": false
+    },
+    {
+      "query_id": "eq9",
+      "precision_at_k": 0.0,
+      "recall_at_k": 0.0,
+      "citation_coverage": 1.0,
+      "groundedness_score": 1.0,
+      "hallucination_detected": false
+    },
+    {
+      "query_id": "eq10",
+      "precision_at_k": 0.0,
+      "recall_at_k": 0.0,
+      "citation_coverage": 1.0,
+      "groundedness_score": 1.0,
+      "hallucination_detected": false
+    }
+  ]
+}

--- a/scripts/validate_chunking.py
+++ b/scripts/validate_chunking.py
@@ -5,8 +5,8 @@ Validate token chunking on real corpus.
 Run from project root:
 
     python scripts/run_ingestion.py
-    python scripts/test_structural_segmenter.py  # optional: segment first
-    python scripts/test_chunking.py
+    python scripts/validate_structural_segmenter.py  # optional: segment first
+    python scripts/validate_chunking.py
 """
 
 import json

--- a/scripts/validate_pdf_loader.py
+++ b/scripts/validate_pdf_loader.py
@@ -6,7 +6,7 @@ Example
 -------
 Run from the project root:
 
-    python scripts/test_pdf_loader.py
+    python scripts/validate_pdf_loader.py
 """
 
 from pathlib import Path

--- a/scripts/validate_structural_segmenter.py
+++ b/scripts/validate_structural_segmenter.py
@@ -4,7 +4,7 @@ Validate structural segmentation on real corpus.
 
 Run from project root:
 
-    python scripts/test_structural_segmenter.py
+    python scripts/validate_structural_segmenter.py
 """
 
 import json

--- a/src/demo/demo_service.py
+++ b/src/demo/demo_service.py
@@ -3,6 +3,7 @@
 import time
 from typing import Any
 
+from src.utils.document_aliases import get_document_alias
 from src.utils.system_checks import check_rag_dependencies
 
 
@@ -75,6 +76,7 @@ def run_rag_query(query: str, top_k: int = 5) -> dict[str, Any]:
     chunks = [
         {
             "document_id": c.document_id,
+            "document_alias": get_document_alias(c.document_id),
             "page": c.page_number,
             "section": c.section_title or "—",
             "text": c.text[:500] + ("..." if len(c.text) > 500 else ""),

--- a/src/embeddings/embedding_generator.py
+++ b/src/embeddings/embedding_generator.py
@@ -38,6 +38,10 @@ def generate_embeddings(
     model = get_embedding_model(model_name)
     texts = [c.text for c in chunks]
 
+    # NOTE: normalize_embeddings=False here is intentional.
+    # Weaviate uses cosine distance natively and handles un-normalized vectors correctly.
+    # Query embeddings in query_embedding.py use normalize=True for direct dot-product
+    # similarity, but cosine distance is invariant to L2 norm, so results are equivalent.
     embeddings = model.encode(
         texts,
         batch_size=batch_size,

--- a/src/llm/baseline_llm.py
+++ b/src/llm/baseline_llm.py
@@ -38,7 +38,8 @@ class BaselineLLM(LLMClient):
             options={
                 "temperature": self.temperature,
                 "top_p": self.top_p,
-                "num_predict": 2048,
+                "num_predict": 512,   # max response tokens — enough for regulatory answers
+                "num_ctx": 2048,      # KV cache window — keeps prefill fast on CPU/GPU
             },
         )
 

--- a/src/observability/__init__.py
+++ b/src/observability/__init__.py
@@ -1,1 +1,5 @@
 """Observability module - Phoenix tracing and monitoring."""
+
+from .tracing import span_set_input, span_set_output, trace_span
+
+__all__ = ["trace_span", "span_set_input", "span_set_output"]

--- a/src/rag/context_builder.py
+++ b/src/rag/context_builder.py
@@ -2,54 +2,34 @@
 
 from typing import TYPE_CHECKING
 
+from src.utils.document_aliases import get_document_alias
+
 if TYPE_CHECKING:
     from src.retrieval.retriever import RetrievalResult
 
-# Approximate tokens per char for Portuguese (conservative)
 CHARS_PER_TOKEN = 4
 
 
 def _count_tokens(text: str) -> int:
-    """
-    Estimate token count for truncation.
-
-    Uses character-based heuristic (1 token ≈ 4 chars) to avoid
-    loading a heavy tokenizer. This approximation is sufficient
-    to ensure the constructed context stays within safe limits.
-    """
     return len(text) // CHARS_PER_TOKEN
 
 
 def build_context(
     chunks: list["RetrievalResult"],
-    max_chunks: int = 5,
+    max_chunks: int = 3,
     max_tokens: int | None = None,
 ) -> str:
     """
     Build context string from retrieved chunks with truncation.
 
-    Parameters
-    ----------
-    chunks : list[RetrievalResult]
-        Retrieved chunks ordered by relevance.
-    max_chunks : int, default 5
-        Maximum number of chunks included in the context.
-    max_tokens : int | None
-        Maximum token budget for the full context. If exceeded,
-        the context is truncated by removing the least relevant
-        chunks or shortening the last chunk.
-
-    Returns
-    -------
-    str
-        Concatenated context with source markers.
+    Markers use human-readable document aliases so the LLM cites correctly.
     """
-
     limited = chunks[:max_chunks]
     parts: list[str] = []
 
     for r in limited:
-        marker = f"[{r.document_id} p.{r.page_number}]"
+        alias = get_document_alias(r.document_id)
+        marker = f"[{alias}, p. {r.page_number}]"
         parts.append(f"{marker}\n{r.text}")
 
     context = "\n\n".join(parts)
@@ -60,20 +40,16 @@ def build_context(
     if _count_tokens(context) <= max_tokens:
         return context
 
-    # Remove chunks from the end until under token limit
     for i in range(len(limited) - 1, 0, -1):
         truncated = "\n\n".join(parts[:i])
         if _count_tokens(truncated) <= max_tokens:
             return truncated
 
-    # Final fallback: truncate the last chunk
     if parts:
         max_chars = max_tokens * CHARS_PER_TOKEN
         prefix = "\n\n".join(parts[:-1])
         sep = "\n\n" if prefix else ""
         allowed = max_chars - len(prefix) - len(sep)
-
         if allowed > 0:
             parts[-1] = parts[-1][:allowed].rstrip() + "..."
-
     return "\n\n".join(parts)

--- a/src/rag/prompt_template.py
+++ b/src/rag/prompt_template.py
@@ -1,16 +1,16 @@
 """Structured prompt template for RAG with clear delimiters."""
 
-SYSTEM_INSTRUCTION = """You are an expert assistant specialized in Brazilian Pix regulation (Banco Central norms, circulars, and related legislation).
+SYSTEM_INSTRUCTION = """You are an expert assistant specialized in Brazilian Pix documentation — including operational manuals, technical specifications, regulatory norms, and brand guidelines published by the Banco Central do Brasil (BCB).
 
-Your role is to provide accurate, well-founded answers based exclusively on the regulatory context provided.
+Your role is to provide accurate, well-founded answers based exclusively on the document excerpts provided in the context.
 
 Rules:
 1. Use ONLY information present in the provided context. Do not infer, assume, or add external knowledge.
 2. If the answer is not in the context, clearly state: "Esta informação não está disponível no material fornecido."
-3. When answering, cite the source when relevant (e.g., "Conforme o documento X..." or "De acordo com a Circular...").
-4. Prefer direct quotes from the context when the exact wording matters for legal/regulatory precision.
+3. When answering, cite the source document when relevant (e.g., "Conforme o Manual de Tempos do Pix..." or "De acordo com o Manual Operacional do DICT...").
+4. Prefer direct quotes from the context when the exact wording matters for precision.
 5. Keep answers concise but complete. Avoid redundancy.
-6. If the question is ambiguous or outside the scope of Pix regulation, say so explicitly."""
+6. If the question is ambiguous or outside the scope of the provided Pix documentation, say so explicitly."""
 
 
 def build_prompt(context: str, query: str) -> str:

--- a/src/rag/rag_pipeline.py
+++ b/src/rag/rag_pipeline.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Callable
 
 from src.retrieval.retriever import RetrievalResult, retrieve
+from src.utils.document_aliases import get_document_alias
 
 from .context_builder import build_context
 from src.llm import LLMClient
@@ -16,6 +17,7 @@ except ImportError:
 
     def trace_span(name: str, attributes=None, openinference_span_kind=None):
         from contextlib import nullcontext
+
         return nullcontext()
 
     def span_set_input(span, value): ...
@@ -32,14 +34,16 @@ def _truncate(s: str, max_len: int = MAX_ATTR_LEN) -> str:
 
 
 def _build_citations(chunks: list[RetrievalResult]) -> list[str]:
-    """Build deterministic citations from retrieved chunks."""
+    # Deduplicate by (resolved_alias, page) so that legacy and current document_ids
+    # for the same document don't produce duplicate citation entries.
     seen: set[tuple[str, int]] = set()
     citations: list[str] = []
     for r in chunks:
-        key = (r.document_id, r.page_number)
+        alias = get_document_alias(r.document_id)
+        key = (alias, r.page_number)
         if key not in seen:
             seen.add(key)
-            citations.append(f"{r.document_id} p.{r.page_number}")
+            citations.append(f"{alias}, p. {r.page_number}")
     return citations
 
 
@@ -47,15 +51,8 @@ def _format_answer_with_citations(answer: str, citations: list[str]) -> str:
     """Append citation footer so the user knows where to verify the information."""
     if not citations:
         return answer
-
     refs = ", ".join(citations)
-
-    footer = (
-        "\n\n---\n"
-        f"*Fontes consultadas: {refs}. "
-        "Para verificar, consulte os documentos originais citados.*"
-    )
-
+    footer = f"\n\n---\n*Fontes consultadas: {refs}. Para verificar, consulte os documentos originais citados.*"
     return answer.rstrip() + footer
 
 
@@ -79,14 +76,15 @@ def answer_query(
     query: str,
     llm: LLMClient,
     top_k: int = 5,
-    max_chunks: int = 5,
-    max_context_tokens: int | None = 4096,
+    max_chunks: int = 3,
+    max_context_tokens: int | None = 1500,
     retriever: Callable[[str, int], list[RetrievalResult]] | None = None,
 ) -> RAGResponse:
     """
     Answer a query using RAG: retrieve → build context → prompt → generate.
-    """
 
+    Returns RAGResponse with answer including citation footer for verification.
+    """
     retrieve_fn = retriever or _default_retrieve
 
     with trace_span("rag_pipeline", openinference_span_kind="chain") as parent_span:
@@ -94,74 +92,65 @@ def answer_query(
 
         with trace_span("retrieval", openinference_span_kind="retriever") as span:
             chunks = retrieve_fn(query, top_k)
-
             if span and span.is_recording():
                 span_set_input(span, query)
-
                 for i, c in enumerate(chunks):
-                    doc_id = c.chunk_id or c.document_id or str(i)
-
-                    span.set_attribute(f"retrieval.documents.{i}.document.id", doc_id)
-                    span.set_attribute(
-                        f"retrieval.documents.{i}.document.content",
-                        _truncate(c.text),
-                    )
-
-                    meta = f"document_id={c.document_id}, page={c.page_number}"
-
+                    alias = get_document_alias(c.document_id)
+                    span.set_attribute(f"retrieval.documents.{i}.document.id", c.chunk_id or c.document_id or str(i))
+                    span.set_attribute(f"retrieval.documents.{i}.document.content", _truncate(c.text))
+                    if c.similarity_score is not None:
+                        span.set_attribute(f"retrieval.documents.{i}.document.score", round(c.similarity_score, 4))
+                    meta = f"source={alias}, page={c.page_number}"
                     if c.section_title:
                         meta += f", section={c.section_title}"
-
-                    span.set_attribute(
-                        f"retrieval.documents.{i}.document.metadata", meta
-                    )
-
+                    span.set_attribute(f"retrieval.documents.{i}.document.metadata", meta)
                 span_set_output(
                     span,
                     {
                         "count": len(chunks),
-                        "refs": [f"{c.document_id} p.{c.page_number}" for c in chunks],
+                        "refs": [
+                            f"{get_document_alias(c.document_id)}, p. {c.page_number}"
+                            for c in chunks
+                        ],
                     },
                 )
 
         with trace_span("context_building", openinference_span_kind="chain") as span:
-            context = build_context(chunks, max_chunks=max_chunks, max_tokens=max_context_tokens)
-
+            context = build_context(
+                chunks, max_chunks=max_chunks, max_tokens=max_context_tokens
+            )
             if span and span.is_recording():
                 span_set_input(span, {"chunk_count": len(chunks)})
                 span_set_output(span, _truncate(context))
 
-        with trace_span("prompt_construction", openinference_span_kind="prompt") as span:
+        with trace_span(
+            "prompt_construction", openinference_span_kind="prompt"
+        ) as span:
             prompt = build_prompt(context, query)
-
             if span and span.is_recording():
-                span_set_input(span, {"context_len": len(context), "query": query[:200]})
+                span_set_input(
+                    span, {"context_len": len(context), "query": query[:200]}
+                )
                 span_set_output(span, _truncate(prompt))
 
         with trace_span("llm_generation", openinference_span_kind="llm") as span:
-            answer, usage = llm.generate(prompt)
-
-            citations = _build_citations(chunks)
-
             if span and span.is_recording():
-                span_set_output(
-                    span,
-                    {
-                        "answer": _truncate(answer),
-                        "citations": citations,
-                    },
-                )
-
+                model_name = getattr(llm, "model", "unknown")
+                span.set_attribute("llm.model_name", model_name)
+                span.set_attribute("llm.invocation_parameters", _truncate(prompt))
+            answer, usage = llm.generate(prompt)
+            citations = _build_citations(chunks)
+            if span and span.is_recording():
+                span_set_output(span, {"answer": _truncate(answer), "citations": citations})
                 if usage:
                     span.set_attribute("llm.token_count.prompt", usage.prompt_tokens)
                     span.set_attribute("llm.token_count.completion", usage.completion_tokens)
+                    span.set_attribute("llm.token_count.total", usage.total_tokens)
 
         answer_with_citations = _format_answer_with_citations(answer, citations)
-
         if parent_span and parent_span.is_recording():
             span_set_output(
-                parent_span,
-                {"answer": answer_with_citations, "citations": citations},
+                parent_span, {"answer": answer_with_citations, "citations": citations}
             )
 
     return RAGResponse(

--- a/src/utils/document_aliases.py
+++ b/src/utils/document_aliases.py
@@ -1,0 +1,37 @@
+"""Document alias lookup — maps raw document_id to human-readable display names."""
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_ALIASES_PATH = Path(__file__).resolve().parent.parent.parent / "config" / "document_aliases.yaml"
+_ALIASES: dict[str, str] | None = None
+
+
+def _load_aliases() -> dict[str, str]:
+    """Load aliases from YAML config file. Returns empty dict on failure."""
+    try:
+        import yaml  # pyyaml — already installed as transitive dep of Streamlit
+
+        with open(_ALIASES_PATH, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        return data if isinstance(data, dict) else {}
+    except FileNotFoundError:
+        logger.debug("document_aliases.yaml not found at %s", _ALIASES_PATH)
+        return {}
+    except Exception as e:
+        logger.warning("Failed to load document aliases: %s", e)
+        return {}
+
+
+def get_document_alias(document_id: str) -> str:
+    """
+    Return display alias for a document_id.
+
+    Falls back to document_id itself when no alias is registered.
+    """
+    global _ALIASES
+    if _ALIASES is None:
+        _ALIASES = _load_aliases()
+    return _ALIASES.get(document_id, document_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,40 @@
+"""Shared pytest fixtures for the RAG Pix Regulation test suite."""
+
+import pytest
+
+from src.chunking.models import Chunk, StructuralSegment
+
+
+@pytest.fixture
+def sample_chunk() -> Chunk:
+    """Minimal valid Chunk instance for testing serialization and indexing."""
+    return Chunk(
+        chunk_id="doc_p1_s0_c0",
+        document_id="doc",
+        page_number=1,
+        segment_index=0,
+        chunk_index=0,
+        section_title="1 Chaves",
+        article_numbers=["Art. 1º"],
+        source_file="doc.pdf",
+        text="Sample chunk text.",
+        token_count=4,
+        char_start=0,
+        char_end=18,
+    )
+
+
+@pytest.fixture
+def sample_segment() -> StructuralSegment:
+    """Minimal valid StructuralSegment instance for testing."""
+    return StructuralSegment(
+        document_id="doc",
+        page_number=1,
+        segment_index=0,
+        section_title="1 Chaves Pix",
+        article_numbers=["Art. 1º"],
+        source_file="doc.pdf",
+        text="Conteúdo regulatório de exemplo.",
+        char_start=0,
+        char_end=32,
+    )

--- a/tests/test_prompt_template.py
+++ b/tests/test_prompt_template.py
@@ -27,9 +27,9 @@ def test_build_prompt_includes_sections() -> None:
 def test_build_prompt_includes_system_instruction() -> None:
     """System instruction is embedded."""
     prompt = build_prompt(context="x", query="y")
-    assert "Brazilian Pix regulation" in prompt
-    assert "only the provided regulatory context" in prompt
-    assert "not present" in prompt or "not available" in prompt
+    assert "Brazilian Pix" in prompt
+    assert "ONLY" in prompt or "exclusively" in prompt
+    assert "not present" in prompt or "not available" in prompt or "não está disponível" in prompt
 
 
 def test_build_prompt_deterministic() -> None:

--- a/tests/test_prompt_template.py
+++ b/tests/test_prompt_template.py
@@ -1,6 +1,16 @@
 """Unit tests for RAG prompt template."""
 
-from src.rag.prompt_template import build_prompt
+import importlib.util
+from pathlib import Path
+
+# Load prompt_template directly to avoid pulling in rag_pipeline (sentence_transformers)
+_spec = importlib.util.spec_from_file_location(
+    "prompt_template",
+    Path(__file__).resolve().parent.parent / "src" / "rag" / "prompt_template.py",
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+build_prompt = _mod.build_prompt
 
 
 def test_build_prompt_includes_sections() -> None:

--- a/tests/test_prompt_template.py
+++ b/tests/test_prompt_template.py
@@ -1,6 +1,6 @@
 """Unit tests for RAG prompt template."""
 
-from src.rag.prompt_template import SYSTEM_INSTRUCTION, build_prompt
+from src.rag.prompt_template import build_prompt
 
 
 def test_build_prompt_includes_sections() -> None:

--- a/tests/test_token_chunker.py
+++ b/tests/test_token_chunker.py
@@ -1,5 +1,7 @@
 """Unit tests for token-based chunking."""
 
+import pytest
+
 from src.chunking import chunk_segment, chunk_segments, chunk_records
 from src.chunking.models import StructuralSegment
 from src.chunking.token_chunker import (
@@ -60,11 +62,8 @@ def test_chunk_overlap_validation() -> None:
         source_file="doc.pdf",
         text="Some text.",
     )
-    try:
+    with pytest.raises(ValueError, match="overlap"):
         chunk_segment(segment, chunk_size=100, chunk_overlap=100)
-        assert False, "Expected ValueError"
-    except ValueError as e:
-        assert "overlap" in str(e).lower()
 
 
 def test_chunk_metadata_preserved() -> None:


### PR DESCRIPTION
## Context

Previous milestones implemented the full RAG pipeline, including:

- document ingestion and preprocessing
- structure-aware segmentation and token chunking
- embedding generation using BGE-M3
- vector indexing with Weaviate
- semantic retrieval
- RAG pipeline orchestration
- evaluation metrics and Phoenix-based observability

At this stage the system was functionally complete, but still lacked a clear way to demonstrate the system interactively and communicate its architecture and methodology.

This PR introduces the **interactive demo interface and documentation improvements required to present the project as a production-quality portfolio system.**

---

## Objective

Expose the RAG pipeline through an interactive interface and improve transparency of retrieval and generation steps while expanding technical documentation and reproducibility.

---

## Scope Delivered

### Streamlit Demo Interface

Adds a Streamlit application enabling interactive querying of the RAG system.

The interface allows users to:

- submit natural language questions
- run the full RAG pipeline
- inspect generated responses
- compare baseline LLM vs retrieval-augmented responses
- visualize retrieved context and citations

Main component:

```
app/streamlit_app.py
```

---

### Baseline vs RAG Comparison

The interface includes side-by-side responses from:

Baseline LLM (no retrieval)  
RAG pipeline (retrieval + grounded generation)

This demonstrates the practical impact of retrieval augmentation on response quality.

---

### Retrieved Context Visualization

The demo exposes the retrieved context used during generation, including:

- retrieved document chunks
- document identifiers
- page references
- ranking order

This improves transparency and helps explain how answers are generated.

---

### Demo Service Layer

Introduces a small service layer used by the UI to interact with the RAG system:

- run_rag_query
- run_baseline_query
- get_demo_health

File:

```
src/demo/demo_service.py
```

---

### Architecture Documentation

Adds architecture diagrams describing the system pipeline:

- ingestion pipeline
- structural segmentation and chunking
- embedding generation
- retrieval flow
- RAG pipeline orchestration

Files added under:

```
docs/architecture/
```

Documentation updated:

```
docs/ARCHITECTURE.md
```

---

### Evaluation Documentation

Adds a detailed description of the evaluation methodology and workflow.

File:

```
docs/EVALUATION.md
```

---

### Observability Integration

Registers the Phoenix tracer at Streamlit app startup, enabling visualization of:

- rag_pipeline execution
- retrieval stage
- context construction
- prompt creation
- LLM generation

When Phoenix is running locally, traces are available at:

```
http://localhost:6006
```

---

### Project Infrastructure Improvements

Additional improvements included in this PR:

- add CI workflow for repository validation
- introduce Makefile for development tasks
- add configuration files for environment and document aliases
- rename validation scripts for consistency
- apply ruff linting and formatting fixes

---

## Files Added / Updated

Key additions and updates include:

- Streamlit demo interface  
- demo service layer  
- architecture diagrams  
- evaluation documentation  
- CI workflow configuration  
- project configuration files  

Total impact:

```
25 files changed
~975 insertions
~362 deletions
```

---

## Validation

- [x] Streamlit demo runs locally
- [x] baseline vs RAG comparison functional
- [x] retrieved context visualization working
- [x] Phoenix traces visible when Phoenix server is running
- [x] documentation expanded
- [x] repository ready for portfolio publication

---

## Milestone

v0.8 — Demo Interface & Publication

Target release: **v1.0.0**

---

Closes #48  
Closes #49  
Closes #50  
Closes #52