### PR TITLE
feat: implement evaluation foundation

### DIFF
--- a/data/evaluation/rag_evaluation_dataset.json
+++ b/data/evaluation/rag_evaluation_dataset.json
@@ -1,13 +1,20 @@
 {
   "description": "Canonical evaluation dataset — Manual Operacional do DICT. Single source for retrieval and RAG evaluation.",
   "source_corpus": "manual_dict",
+  "difficulty_tiers": {
+    "single_chunk": "Answer found in a single chunk",
+    "multi_chunk": "Answer requires combining information from 2+ chunks",
+    "cross_section": "Answer requires information from different sections",
+    "negative": "Answer is NOT in the corpus — tests abstention"
+  },
   "queries": [
     {
       "query_id": "eq1",
       "query": "O que é o processo de Recuperação de Valores no Pix e qual é seu objetivo?",
+      "difficulty": "single_chunk",
       "expected_pages": [122],
       "expected_documents": ["manual_dict"],
-      "expected_answer_summary": "A Recuperação de Valores é um mecanismo utilizado para rastrear, bloquear e eventualmente devolver recursos associados a transações Pix suspeitas de fraude ou golpe.",
+      "expected_answer_summary": "A Recuperação de Valores é um aprimoramento do MED para rastrear, bloquear e devolver recursos em transações Pix suspeitas de fraude ou golpe.",
       "key_concepts": [
         "rastreamento de transações",
         "bloqueio de recursos",
@@ -21,6 +28,7 @@
     {
       "query_id": "eq2",
       "query": "Quais são as principais etapas do processo de Recuperação de Valores no DICT?",
+      "difficulty": "multi_chunk",
       "expected_pages": [123, 124],
       "expected_documents": ["manual_dict"],
       "expected_answer_summary": "O processo inclui as etapas: instauração, rastreamento, priorização, bloqueio, análise e devolução.",
@@ -36,6 +44,7 @@
     {
       "query_id": "eq3",
       "query": "Quais são os possíveis estados de uma Recuperação de Valores no DICT?",
+      "difficulty": "single_chunk",
       "expected_pages": [122],
       "expected_documents": ["manual_dict"],
       "expected_answer_summary": "Uma Recuperação de Valores pode ter os seguintes estados: CREATED, TRACKED, AWAITING_ANALYSIS, ANALYSED, REFUNDING, COMPLETED, CANCELLED.",
@@ -50,6 +59,7 @@
     {
       "query_id": "eq4",
       "query": "Quem pode abrir uma notificação de infração para solicitação de devolução?",
+      "difficulty": "single_chunk",
       "expected_pages": [69],
       "expected_documents": ["manual_dict"],
       "expected_answer_summary": "A notificação de infração para solicitação de devolução pode ser aberta apenas pelo PSP do pagador quando há suspeita de fraude em uma transação Pix.",
@@ -65,6 +75,7 @@
     {
       "query_id": "eq5",
       "query": "Quais são os estados possíveis de uma notificação de infração no DICT?",
+      "difficulty": "single_chunk",
       "expected_pages": [69],
       "expected_documents": ["manual_dict"],
       "expected_answer_summary": "Uma notificação de infração pode estar nos estados: aberta, recebida, analisada/concluída/fechada, cancelada.",
@@ -79,9 +90,10 @@
     {
       "query_id": "eq6",
       "query": "Em que situações pode ser criada uma marcação de fraude transacional no DICT?",
+      "difficulty": "single_chunk",
       "expected_pages": [84],
       "expected_documents": ["manual_dict"],
-      "expected_answer_summary": "A marcação de fraude pode ser criada quando um PSP identifica que um usuário está envolvido em fraude, como golpes, transações não autorizadas ou contas utilizadas para receber recursos ilícitos.",
+      "expected_answer_summary": "A marcação de fraude pode ser criada quando um PSP identifica envolvimento em fraude, como conta-laranja, conta de fraudador, acesso fraudulento ou outros.",
       "key_concepts": [
         "fraude transacional",
         "marcação de usuário fraudador",
@@ -94,6 +106,7 @@
     {
       "query_id": "eq7",
       "query": "Quais informações devem ser fornecidas ao criar uma marcação de fraude transacional no DICT?",
+      "difficulty": "single_chunk",
       "expected_pages": [84],
       "expected_documents": ["manual_dict"],
       "expected_answer_summary": "Devem ser informados: CPF ou CNPJ do usuário suspeito, chave Pix (quando conhecida), tipo de fraude e informações adicionais sobre o caso.",
@@ -109,6 +122,7 @@
     {
       "query_id": "eq8",
       "query": "Qual é o prazo para que o PSP do pagador inicie uma solicitação de devolução após a conclusão da notificação de infração?",
+      "difficulty": "single_chunk",
       "expected_pages": [105],
       "expected_documents": ["manual_dict"],
       "expected_answer_summary": "O PSP do pagador tem até 72 horas após a conclusão da notificação de infração para iniciar a solicitação de devolução.",
@@ -124,7 +138,8 @@
     {
       "query_id": "eq9",
       "query": "O valor solicitado para devolução em um processo de fraude pode ser maior que o valor da transação original?",
-      "expected_pages": [106],
+      "difficulty": "single_chunk",
+      "expected_pages": [106, 130],
       "expected_documents": ["manual_dict"],
       "expected_answer_summary": "Não. O valor solicitado para devolução deve ser igual ou menor que o valor da transação original.",
       "key_concepts": [
@@ -132,12 +147,14 @@
         "valor da transação original"
       ],
       "relevant_sources": [
-        {"section": "17", "section_title": "Fluxo de devolução", "pages": [106]}
+        {"section": "17", "section_title": "Fluxo de devolução", "pages": [106]},
+        {"section": "20", "pages": [130]}
       ]
     },
     {
       "query_id": "eq10",
       "query": "O que acontece quando uma solicitação de devolução é concluída no DICT?",
+      "difficulty": "multi_chunk",
       "expected_pages": [106, 107],
       "expected_documents": ["manual_dict"],
       "expected_answer_summary": "A solicitação é marcada como concluída no DICT com um dos seguintes resultados: aceita total, aceita parcial ou rejeitada. O PSP do pagador consulta periodicamente essas solicitações concluídas.",
@@ -149,14 +166,480 @@
       "relevant_sources": [
         {"section": "17", "section_title": "Fluxo de devolução", "pages": [106, 107]}
       ]
+    },
+    {
+      "query_id": "eq11",
+      "query": "Quais são os tipos de chaves Pix aceitos no DICT e seus formatos?",
+      "difficulty": "single_chunk",
+      "expected_pages": [5],
+      "expected_documents": ["manual_dict"],
+      "expected_answer_summary": "Os tipos de chave são: telefone celular (formato E.164), e-mail, CPF (11 dígitos), CNPJ (14 dígitos) e chave aleatória (EVP, UUID v4).",
+      "key_concepts": [
+        "tipos de chave Pix",
+        "formato E.164",
+        "EVP",
+        "CPF",
+        "CNPJ"
+      ],
+      "relevant_sources": [
+        {"section": "1", "section_title": "Chaves Pix", "pages": [5]}
+      ]
+    },
+    {
+      "query_id": "eq12",
+      "query": "Como o participante do Pix deve validar o número de telefone celular ou e-mail antes do registro da chave?",
+      "difficulty": "single_chunk",
+      "expected_pages": [6],
+      "expected_documents": ["manual_dict"],
+      "expected_answer_summary": "O participante deve enviar um código para o telefone ou e-mail e solicitar a inclusão desse código em algum canal de atendimento, validando a posse do dado.",
+      "key_concepts": [
+        "validação de posse",
+        "código de verificação",
+        "registro de chave"
+      ],
+      "relevant_sources": [
+        {"section": "1", "pages": [6]}
+      ]
+    },
+    {
+      "query_id": "eq13",
+      "query": "Quais verificações de conformidade o DICT realiza ao receber uma solicitação de registro de chave Pix?",
+      "difficulty": "single_chunk",
+      "expected_pages": [10],
+      "expected_documents": ["manual_dict"],
+      "expected_answer_summary": "O DICT verifica: i) se o PSP com acesso direto possui autorização para registrar chaves, e ii) se o PSP vinculado à chave é o mesmo do usuário final.",
+      "key_concepts": [
+        "verificação de conformidade",
+        "autorização do PSP",
+        "registro de chave"
+      ],
+      "relevant_sources": [
+        {"section": "3.1", "section_title": "Fluxo de registro de chave", "pages": [10]}
+      ]
+    },
+    {
+      "query_id": "eq14",
+      "query": "Como funciona o fluxo de registro de chave para participantes com acesso indireto ao DICT?",
+      "difficulty": "multi_chunk",
+      "expected_pages": [11, 12],
+      "expected_documents": ["manual_dict"],
+      "expected_answer_summary": "O PSP com acesso indireto solicita o registro ao PSP com acesso direto (liquidante no SPI), que encaminha a requisição ao DICT. A resposta segue o caminho inverso.",
+      "key_concepts": [
+        "acesso indireto",
+        "PSP liquidante",
+        "intermediação de registro"
+      ],
+      "relevant_sources": [
+        {"section": "3.2", "section_title": "Fluxo de registro com acesso indireto", "pages": [11, 12]}
+      ]
+    },
+    {
+      "query_id": "eq15",
+      "query": "Quais verificações o DICT faz ao receber uma solicitação de exclusão de chave?",
+      "difficulty": "single_chunk",
+      "expected_pages": [20],
+      "expected_documents": ["manual_dict"],
+      "expected_answer_summary": "O DICT verifica: i) a chave está registrada, ii) o PSP que solicitou é o mesmo que efetuou o registro, e iii) a chave pertence ao usuário que solicitou a exclusão.",
+      "key_concepts": [
+        "exclusão de chave",
+        "verificação de titularidade",
+        "DICT"
+      ],
+      "relevant_sources": [
+        {"section": "4", "section_title": "Fluxo de exclusão", "pages": [20]}
+      ]
+    },
+    {
+      "query_id": "eq16",
+      "query": "Como funciona o fluxo de exclusão de chave para participantes com acesso indireto ao DICT?",
+      "difficulty": "single_chunk",
+      "expected_pages": [21],
+      "expected_documents": ["manual_dict"],
+      "expected_answer_summary": "O PSP do usuário final inicia o processo de exclusão enviando a mensagem 'Diretório / Remover Vínculo' ao DICT através do PSP com acesso direto.",
+      "key_concepts": [
+        "exclusão via acesso indireto",
+        "mensagem Remover Vínculo"
+      ],
+      "relevant_sources": [
+        {"section": "4.2", "pages": [21]}
+      ]
+    },
+    {
+      "query_id": "eq17",
+      "query": "O que é o processo de portabilidade de chave Pix e como ele é iniciado?",
+      "difficulty": "single_chunk",
+      "expected_pages": [24],
+      "expected_documents": ["manual_dict"],
+      "expected_answer_summary": "A portabilidade permite transferir uma chave de um PSP para outro. O PSP reivindicador inicia o pedido, que fica com status 'Aberto' no DICT aguardando resposta do PSP doador.",
+      "key_concepts": [
+        "portabilidade de chave",
+        "PSP reivindicador",
+        "PSP doador",
+        "status Aberto"
+      ],
+      "relevant_sources": [
+        {"section": "5.1", "section_title": "Fluxo de portabilidade", "pages": [24, 25]}
+      ]
+    },
+    {
+      "query_id": "eq18",
+      "query": "Qual o prazo que o usuário tem para confirmar ou cancelar uma portabilidade de chave Pix?",
+      "difficulty": "single_chunk",
+      "expected_pages": [30],
+      "expected_documents": ["manual_dict"],
+      "expected_answer_summary": "O usuário tem até sete dias para confirmar ou cancelar a portabilidade. Para cancelar, deve fazer validação ativa da chave.",
+      "key_concepts": [
+        "prazo de 7 dias",
+        "validação ativa",
+        "cancelamento de portabilidade"
+      ],
+      "relevant_sources": [
+        {"section": "5", "pages": [30]}
+      ]
+    },
+    {
+      "query_id": "eq19",
+      "query": "O que acontece quando o status da portabilidade é 'Confirmado' no DICT?",
+      "difficulty": "single_chunk",
+      "expected_pages": [35],
+      "expected_documents": ["manual_dict"],
+      "expected_answer_summary": "Quando confirmado, o DICT bloqueia a chave até o recebimento da confirmação pelo PSP reivindicador. O bloqueio impede consultas a essa chave.",
+      "key_concepts": [
+        "bloqueio de chave",
+        "PSP reivindicador",
+        "confirmação de portabilidade"
+      ],
+      "relevant_sources": [
+        {"section": "5", "pages": [35]}
+      ]
+    },
+    {
+      "query_id": "eq20",
+      "query": "O que é o fluxo de reivindicação de posse de chave Pix?",
+      "difficulty": "single_chunk",
+      "expected_pages": [40],
+      "expected_documents": ["manual_dict"],
+      "expected_answer_summary": "A reivindicação de posse ocorre quando um usuário deseja registrar uma chave que já pertence a outro usuário. O PSP doador consulta periodicamente reivindicações com status 'Aberto' no DICT.",
+      "key_concepts": [
+        "reivindicação de posse",
+        "PSP doador",
+        "chave já registrada"
+      ],
+      "relevant_sources": [
+        {"section": "6.3", "section_title": "Fluxo de reivindicação de posse", "pages": [40]}
+      ]
+    },
+    {
+      "query_id": "eq21",
+      "query": "Como funciona o fluxo de consulta de chave Pix pelo usuário pagador?",
+      "difficulty": "multi_chunk",
+      "expected_pages": [55, 56],
+      "expected_documents": ["manual_dict"],
+      "expected_answer_summary": "O usuário pagador insere a chave (manualmente ou via QR Code), o PSP verifica na base interna e, se não encontrar, consulta o DICT através do PSP com acesso direto.",
+      "key_concepts": [
+        "consulta de chave",
+        "QR Code",
+        "base interna",
+        "acesso direto ao DICT"
+      ],
+      "relevant_sources": [
+        {"section": "8", "section_title": "Fluxo de consulta", "pages": [55, 56]}
+      ]
+    },
+    {
+      "query_id": "eq22",
+      "query": "O que é o processo de verificação de sincronismo no DICT e quais são seus conceitos fundamentais?",
+      "difficulty": "single_chunk",
+      "expected_pages": [61],
+      "expected_documents": ["manual_dict"],
+      "expected_answer_summary": "A verificação de sincronismo usa dois conceitos: CID (identificador de conteúdo, 256 bits gerado a partir de dados da chave) e VSync (verificador de sincronismo).",
+      "key_concepts": [
+        "sincronismo",
+        "CID",
+        "VSync",
+        "identificador de conteúdo"
+      ],
+      "relevant_sources": [
+        {"section": "9", "section_title": "Fluxo de verificação de sincronismo", "pages": [61]}
+      ]
+    },
+    {
+      "query_id": "eq23",
+      "query": "Como funciona o fluxo de reconciliação de chaves por arquivo no DICT?",
+      "difficulty": "single_chunk",
+      "expected_pages": [66],
+      "expected_documents": ["manual_dict"],
+      "expected_answer_summary": "O PSP com acesso direto solicita a lista de suas chaves por tipo específico através da mensagem 'Reconciliação / Criar Arquivo' ao DICT.",
+      "key_concepts": [
+        "reconciliação",
+        "arquivo de chaves",
+        "PSP com acesso direto"
+      ],
+      "relevant_sources": [
+        {"section": "9", "pages": [66]}
+      ]
+    },
+    {
+      "query_id": "eq24",
+      "query": "Quais são os tipos de fraude reconhecidos na notificação de infração do DICT?",
+      "difficulty": "single_chunk",
+      "expected_pages": [71],
+      "expected_documents": ["manual_dict"],
+      "expected_answer_summary": "Os tipos incluem: fraudulent_access (acesso e autorização fraudulenta por terceiro via engenharia social) e outros tipos de fraude transacional.",
+      "key_concepts": [
+        "fraudulent_access",
+        "engenharia social",
+        "tipos de fraude"
+      ],
+      "relevant_sources": [
+        {"section": "10.1", "pages": [71]}
+      ]
+    },
+    {
+      "query_id": "eq25",
+      "query": "Quais são os tipos de conta fraudadora reconhecidos na marcação de fraude do DICT?",
+      "difficulty": "single_chunk",
+      "expected_pages": [84],
+      "expected_documents": ["manual_dict"],
+      "expected_answer_summary": "Os tipos incluem: mule_account (conta-laranja aberta legitimamente para receber fraude), scammer_account (conta no nome do próprio fraudador) e other (outros).",
+      "key_concepts": [
+        "mule_account",
+        "scammer_account",
+        "conta-laranja"
+      ],
+      "relevant_sources": [
+        {"section": "10.2", "pages": [84]}
+      ]
+    },
+    {
+      "query_id": "eq26",
+      "query": "O que é a funcionalidade checkKeys do DICT e quem pode usá-la?",
+      "difficulty": "single_chunk",
+      "expected_pages": [90],
+      "expected_documents": ["manual_dict"],
+      "expected_answer_summary": "checkKeys é uma funcionalidade do DICT de uso exclusivo do PSP para confirmar a existência de chaves antes de enviar requisições. Não pode ser disponibilizada aos usuários.",
+      "key_concepts": [
+        "checkKeys",
+        "verificação de existência",
+        "uso exclusivo do PSP"
+      ],
+      "relevant_sources": [
+        {"section": "13", "pages": [90]}
+      ]
+    },
+    {
+      "query_id": "eq27",
+      "query": "Como funciona a política de limitação de requisições à API do DICT?",
+      "difficulty": "multi_chunk",
+      "expected_pages": [91, 92],
+      "expected_documents": ["manual_dict"],
+      "expected_answer_summary": "Cada operação da API tem uma política de limitação com um 'balde' (margem para exceder o limite temporariamente). Diferentes operações têm limites específicos, como 70 requisições/min para checkKeys.",
+      "key_concepts": [
+        "rate limiting",
+        "balde",
+        "limites por operação",
+        "API do DICT"
+      ],
+      "relevant_sources": [
+        {"section": "14", "section_title": "Limitação de requisições", "pages": [91, 92]}
+      ]
+    },
+    {
+      "query_id": "eq28",
+      "query": "O que é o cache de existência de chave Pix e qual sua finalidade?",
+      "difficulty": "single_chunk",
+      "expected_pages": [95],
+      "expected_documents": ["manual_dict"],
+      "expected_answer_summary": "O cache de existência permite ao PSP com acesso indireto armazenar localmente informações sobre existência de chaves, atualizado via lista do DICT.",
+      "key_concepts": [
+        "cache local",
+        "existência de chave",
+        "acesso indireto"
+      ],
+      "relevant_sources": [
+        {"section": "16", "section_title": "Cache de existência de chave Pix", "pages": [95]}
+      ]
+    },
+    {
+      "query_id": "eq29",
+      "query": "Qual o prazo máximo para o PSP do pagador solicitar devolução por falha operacional?",
+      "difficulty": "single_chunk",
+      "expected_pages": [100],
+      "expected_documents": ["manual_dict"],
+      "expected_answer_summary": "A solicitação de devolução por falha operacional pode ser feita se a transação ocorreu nos últimos noventa dias.",
+      "key_concepts": [
+        "devolução por falha operacional",
+        "prazo de 90 dias",
+        "PSP do pagador"
+      ],
+      "relevant_sources": [
+        {"section": "17.1", "pages": [100]}
+      ]
+    },
+    {
+      "query_id": "eq30",
+      "query": "Como o PSP do recebedor deve agir ao receber uma solicitação de devolução por falha operacional?",
+      "difficulty": "multi_chunk",
+      "expected_pages": [100, 101],
+      "expected_documents": ["manual_dict"],
+      "expected_answer_summary": "O PSP do recebedor verifica se existem recursos disponíveis na conta. Caso existam, prossegue com a devolução. Caso não se trate de falha operacional ou não existam recursos, segue para rejeição.",
+      "key_concepts": [
+        "verificação de recursos",
+        "falha operacional",
+        "rejeição de devolução"
+      ],
+      "relevant_sources": [
+        {"section": "17.1", "pages": [100, 101]}
+      ]
+    },
+    {
+      "query_id": "eq31",
+      "query": "É possível cancelar uma devolução já aceita pelo PSP do pagador?",
+      "difficulty": "single_chunk",
+      "expected_pages": [110],
+      "expected_documents": ["manual_dict"],
+      "expected_answer_summary": "Sim, o PSP do pagador deve iniciar uma nova transação (pacs.008) para cancelar, pois não é possível devolver a devolução original via pacs.004.",
+      "key_concepts": [
+        "cancelamento de devolução",
+        "nova transação",
+        "pacs.008"
+      ],
+      "relevant_sources": [
+        {"section": "17", "pages": [110]}
+      ]
+    },
+    {
+      "query_id": "eq32",
+      "query": "O que são as notificações de eventos no DICT e qual sua finalidade?",
+      "difficulty": "single_chunk",
+      "expected_pages": [140],
+      "expected_documents": ["manual_dict"],
+      "expected_answer_summary": "O endpoint de eventos é uma forma centralizada de consultar eventos no DICT que necessitem de ação de um PSP. Inicialmente, somente eventos da Recuperação de Valores são consultados.",
+      "key_concepts": [
+        "endpoint de eventos",
+        "notificações",
+        "Recuperação de Valores"
+      ],
+      "relevant_sources": [
+        {"section": "21", "section_title": "Notificações de eventos", "pages": [140]}
+      ]
+    },
+    {
+      "query_id": "eq33",
+      "query": "Quais eventos existem relacionados à Recuperação de Valores no sistema de notificações?",
+      "difficulty": "single_chunk",
+      "expected_pages": [141],
+      "expected_documents": ["manual_dict"],
+      "expected_answer_summary": "Existe o evento FUNDS_RECOVERY_ANALYSED, que significa que a Recuperação de Valores teve seu status atualizado para ANALYSED.",
+      "key_concepts": [
+        "FUNDS_RECOVERY_ANALYSED",
+        "EntityId",
+        "status ANALYSED"
+      ],
+      "relevant_sources": [
+        {"section": "21.1.1", "pages": [141]}
+      ]
+    },
+    {
+      "query_id": "eq34",
+      "query": "O que acontece com a chave durante o processo de reivindicação de posse quando o status é 'Confirmado'?",
+      "difficulty": "cross_section",
+      "expected_pages": [35, 36],
+      "expected_documents": ["manual_dict"],
+      "expected_answer_summary": "Quando confirmado, o DICT bloqueia a chave e atualiza os dados vinculados, alterando o status da solicitação. O bloqueio impede consultas até a conclusão.",
+      "key_concepts": [
+        "bloqueio de chave",
+        "reivindicação de posse",
+        "atualização de dados"
+      ],
+      "relevant_sources": [
+        {"section": "5", "pages": [35]},
+        {"section": "6", "pages": [36]}
+      ]
+    },
+    {
+      "query_id": "eq35",
+      "query": "Quais regras se aplicam ao nome vinculado a uma chave Pix do tipo CPF ou CNPJ?",
+      "difficulty": "multi_chunk",
+      "expected_pages": [7, 8],
+      "expected_documents": ["manual_dict"],
+      "expected_answer_summary": "O nome não pode conter palavras inexistentes no registro da Receita Federal. Cada palavra deve ser grafada de forma idêntica, com exceções para diacríticos, hífens e caracteres especiais.",
+      "key_concepts": [
+        "nome vinculado à chave",
+        "Receita Federal",
+        "diacríticos",
+        "conformidade de nome"
+      ],
+      "relevant_sources": [
+        {"section": "1", "pages": [7, 8]}
+      ]
+    },
+    {
+      "query_id": "neg1",
+      "query": "Qual é a taxa cobrada pelo Banco Central para cada transação Pix realizada?",
+      "difficulty": "negative",
+      "expected_pages": [],
+      "expected_documents": [],
+      "expected_answer_summary": "Esta informação não está disponível no Manual Operacional do DICT. O manual trata dos aspectos operacionais do diretório, não de tarifação.",
+      "key_concepts": [
+        "taxa",
+        "tarifação",
+        "fora do escopo"
+      ],
+      "relevant_sources": []
+    },
+    {
+      "query_id": "neg2",
+      "query": "Qual é o horário de funcionamento do Pix e existe alguma janela de manutenção?",
+      "difficulty": "negative",
+      "expected_pages": [],
+      "expected_documents": [],
+      "expected_answer_summary": "Esta informação não está no Manual Operacional do DICT. Horários de funcionamento são tratados em outros manuais regulatórios.",
+      "key_concepts": [
+        "horário de funcionamento",
+        "manutenção",
+        "fora do escopo"
+      ],
+      "relevant_sources": []
+    },
+    {
+      "query_id": "neg3",
+      "query": "Qual é o limite máximo de valor para uma transferência Pix entre pessoas físicas?",
+      "difficulty": "negative",
+      "expected_pages": [],
+      "expected_documents": [],
+      "expected_answer_summary": "Limites de valor por transação não são tratados no Manual Operacional do DICT.",
+      "key_concepts": [
+        "limite de valor",
+        "pessoa física",
+        "fora do escopo"
+      ],
+      "relevant_sources": []
+    },
+    {
+      "query_id": "neg4",
+      "query": "Como funciona o Pix Saque e o Pix Troco?",
+      "difficulty": "negative",
+      "expected_pages": [],
+      "expected_documents": [],
+      "expected_answer_summary": "Pix Saque e Pix Troco não são abordados no Manual Operacional do DICT.",
+      "key_concepts": [
+        "Pix Saque",
+        "Pix Troco",
+        "fora do escopo"
+      ],
+      "relevant_sources": []
     }
   ],
   "evaluation_dimensions": {
     "retrieval_relevance": "all",
-    "citation_correctness": "eq1-eq10",
-    "multi_chunk_reasoning": ["eq2", "eq10"],
-    "process_understanding": ["eq1", "eq2", "eq3"],
-    "fraud_rules": ["eq4", "eq6", "eq7"],
-    "procedural_constraints": ["eq8", "eq9"]
+    "citation_correctness": "eq1-eq35",
+    "multi_chunk_reasoning": ["eq2", "eq10", "eq14", "eq21", "eq27", "eq30", "eq35"],
+    "process_understanding": ["eq1", "eq2", "eq3", "eq17", "eq20", "eq22"],
+    "fraud_rules": ["eq4", "eq6", "eq7", "eq24", "eq25"],
+    "procedural_constraints": ["eq8", "eq9", "eq29", "eq31"],
+    "key_management": ["eq11", "eq12", "eq13", "eq15", "eq16", "eq17", "eq18", "eq19", "eq35"],
+    "api_and_infrastructure": ["eq26", "eq27", "eq28", "eq32", "eq33"],
+    "negative_queries": ["neg1", "neg2", "neg3", "neg4"]
   }
 }

--- a/docs/EVALUATION.md
+++ b/docs/EVALUATION.md
@@ -8,8 +8,9 @@ This document describes how to evaluate retrieval quality and RAG grounding for 
 
 The evaluation framework measures:
 
-1. **Retrieval** — Precision@K, Recall@K (page-based relevance)
+1. **Retrieval** — Precision@K, Recall@K, NDCG@K, MAP@K (page-based relevance)
 2. **RAG** — Citation coverage, groundedness, hallucination rate
+3. **By difficulty** — Metrics broken down by query difficulty tier
 
 ---
 
@@ -37,16 +38,56 @@ The evaluation framework measures:
 
 **Location:** `data/evaluation/rag_evaluation_dataset.json`
 
-Each query includes:
+### Query Schema
 
 | Field | Description |
 |-------|-------------|
 | `query` | Natural language question |
+| `difficulty` | Difficulty tier (see below) |
 | `expected_pages` | Page numbers where the answer is grounded |
 | `expected_documents` | Document IDs (e.g. `manual_dict`) |
 | `expected_answer_summary` | Ground truth for groundedness |
 | `key_concepts` | Checklist for answer completeness |
 | `relevant_sources` | Section and pages for reference |
+
+### Difficulty Tiers
+
+| Tier | Description | Purpose |
+|------|-------------|---------|
+| `single_chunk` | Answer found in a single chunk | Baseline retrieval accuracy |
+| `multi_chunk` | Answer requires combining 2+ chunks | Tests context assembly |
+| `cross_section` | Answer spans different document sections | Tests broad retrieval |
+| `negative` | Answer is NOT in the corpus | Tests abstention / hallucination resistance |
+
+### Topic Coverage
+
+The dataset covers these topic areas:
+
+| Dimension | Query IDs | Topics |
+|-----------|-----------|--------|
+| `key_management` | eq11-eq19, eq35 | Key types, registration, exclusion, portability, naming rules |
+| `process_understanding` | eq1-eq3, eq17, eq20, eq22 | Recovery, portability, possession claims, synchronization |
+| `fraud_rules` | eq4, eq6, eq7, eq24, eq25 | Infractions, fraud types, account classifications |
+| `procedural_constraints` | eq8, eq9, eq29, eq31 | Deadlines, value limits, cancellation rules |
+| `api_and_infrastructure` | eq26-eq28, eq32, eq33 | API limits, cache, events, checkKeys |
+| `negative_queries` | neg1-neg4 | Out-of-scope topics (fees, hours, limits, Pix Saque) |
+
+---
+
+## Metrics
+
+### Retrieval Metrics
+
+- **Precision@K** — Fraction of retrieved pages that are relevant
+- **Recall@K** — Fraction of relevant pages found (deduplicated to prevent > 1.0)
+- **NDCG@K** — Normalized Discounted Cumulative Gain — rewards relevant results at higher positions
+- **MAP@K** — Mean Average Precision — combines precision and ranking quality
+
+### RAG Metrics
+
+- **Citation coverage** — Citations match retrieved chunks
+- **Groundedness** — Answer uses context, no hallucination heuristics triggered
+- **Hallucination rate** — Fraction of responses flagged as suspicious
 
 ---
 
@@ -60,10 +101,6 @@ Measures how well the retriever finds relevant pages.
 python scripts/evaluate_retrieval.py
 ```
 
-**Metrics:**
-- **Precision@K** — Fraction of retrieved pages that are relevant
-- **Recall@K** — Fraction of relevant pages that were retrieved
-
 ### 2. Full RAG evaluation
 
 Measures retrieval + generation quality.
@@ -72,16 +109,17 @@ Measures retrieval + generation quality.
 python scripts/evaluate_rag.py
 ```
 
-**Metrics:**
-- **Citation coverage** — Citations match retrieved chunks
-- **Groundedness** — Answer uses context, no hallucination heuristics triggered
-- **Hallucination rate** — Fraction of responses flagged as suspicious
-
 ### 3. View report
 
 ```bash
 cat reports/evaluation_report.json
 ```
+
+The report includes:
+- Aggregated retrieval metrics
+- Aggregated RAG metrics
+- **`by_difficulty`** — Metrics broken down by difficulty tier
+- Per-query results with difficulty labels
 
 ---
 
@@ -107,5 +145,6 @@ For trace visualization during evaluation:
 
 1. Identify relevant chunks via `python scripts/demo_retrieval.py`
 2. Add query to `data/evaluation/rag_evaluation_dataset.json` with:
-   - `query`, `expected_pages`, `expected_documents`
+   - `query`, `difficulty`, `expected_pages`, `expected_documents`
    - Optional: `expected_answer_summary`, `key_concepts`, `relevant_sources`
+3. Choose the appropriate difficulty tier based on expected answer complexity

--- a/scripts/annotate_chunks.py
+++ b/scripts/annotate_chunks.py
@@ -1,0 +1,179 @@
+"""Interactive chunk annotation tool for evaluation dataset.
+
+For each evaluation query, retrieves top-K chunks and allows manual labeling
+of relevance (0=irrelevant, 1=partially relevant, 2=fully relevant).
+
+Annotations are saved back to the evaluation dataset JSON under
+`chunk_annotations` for each query.
+
+Usage:
+    python scripts/annotate_chunks.py [--top-k 10] [--query-id eq1]
+
+Requirements:
+    - Weaviate running with indexed corpus
+    - Evaluation dataset at data/evaluation/rag_evaluation_dataset.json
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Add project root to path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.retrieval.retriever import retrieve
+from src.utils.system_checks import is_weaviate_ready
+
+
+DATASET_PATH = Path("data/evaluation/rag_evaluation_dataset.json")
+
+
+def load_dataset() -> dict:
+    with open(DATASET_PATH, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_dataset(data: dict) -> None:
+    with open(DATASET_PATH, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+
+def annotate_query(query: dict, top_k: int) -> list[dict] | None:
+    """Retrieve chunks for a query and prompt for relevance labels."""
+    print(f"\n{'='*70}")
+    print(f"Query ID: {query['query_id']}")
+    print(f"Query: {query['query']}")
+    print(f"Expected pages: {query.get('expected_pages', [])}")
+    print(f"Expected answer: {query.get('expected_answer_summary', 'N/A')}")
+    print(f"{'='*70}")
+
+    results = retrieve(query["query"], top_k=top_k)
+
+    if not results:
+        print("  No results retrieved.")
+        return None
+
+    annotations = []
+    for i, r in enumerate(results):
+        print(f"\n--- Chunk {i+1}/{len(results)} ---")
+        print(f"  Chunk ID:   {r.chunk_id}")
+        print(f"  Page:       {r.page_number}")
+        print(f"  Section:    {r.section_title or 'N/A'}")
+        print(f"  Similarity: {r.similarity_score:.4f}")
+        print("  Text (first 300 chars):")
+        print(f"  {r.text[:300]}...")
+        print()
+
+        while True:
+            label = input("  Relevance [0=irrelevant, 1=partial, 2=relevant, s=skip query]: ")
+            label = label.strip().lower()
+            if label == "s":
+                return None
+            if label in ("0", "1", "2"):
+                annotations.append({
+                    "chunk_id": r.chunk_id,
+                    "page_number": r.page_number,
+                    "similarity_score": r.similarity_score,
+                    "relevance": int(label),
+                })
+                break
+            print("  Invalid input. Enter 0, 1, 2, or s.")
+
+    return annotations
+
+
+def run_annotation(query_id: str | None = None, top_k: int = 10) -> None:
+    """Run interactive annotation session."""
+    if not is_weaviate_ready():
+        print("ERROR: Weaviate is not running. Start it with: docker compose up -d")
+        sys.exit(1)
+
+    data = load_dataset()
+    queries = data["queries"]
+    annotated_count = 0
+
+    for q in queries:
+        # Skip negative queries
+        if q.get("difficulty") == "negative":
+            continue
+
+        # Filter to specific query if requested
+        if query_id and q["query_id"] != query_id:
+            continue
+
+        # Skip already annotated queries
+        if q.get("chunk_annotations"):
+            existing = len(q["chunk_annotations"])
+            print(f"\n[SKIP] {q['query_id']} already has {existing} annotations.")
+            continue
+
+        annotations = annotate_query(q, top_k)
+
+        if annotations is not None:
+            q["chunk_annotations"] = annotations
+            save_dataset(data)
+            annotated_count += 1
+            print(f"\n  Saved {len(annotations)} annotations for {q['query_id']}.")
+
+        cont = input("\nContinue to next query? [Y/n]: ").strip().lower()
+        if cont == "n":
+            break
+
+    print(f"\nAnnotation complete. {annotated_count} queries annotated.")
+
+
+def report_chunk_quality(data: dict) -> None:
+    """Report chunk quality diagnostics from existing annotations."""
+    print("\n" + "=" * 70)
+    print("CHUNK QUALITY REPORT")
+    print("=" * 70)
+
+    annotated = [q for q in data["queries"] if q.get("chunk_annotations")]
+    if not annotated:
+        print("No annotated queries found. Run annotation first.")
+        return
+
+    total_chunks = 0
+    relevant_chunks = 0
+    boundary_splits = 0
+
+    for q in annotated:
+        anns = q["chunk_annotations"]
+        total_chunks += len(anns)
+        rel = [a for a in anns if a["relevance"] >= 1]
+        relevant_chunks += len(rel)
+
+        # Detect boundary splits: relevant content on expected page but
+        # partial relevance suggests the answer is split across chunks
+        partial = [a for a in anns if a["relevance"] == 1]
+        if len(partial) >= 2:
+            boundary_splits += 1
+
+        print(f"\n{q['query_id']} ({q.get('difficulty', '?')}):")
+        print(f"  Chunks: {len(anns)} total, {len(rel)} relevant, {len(partial)} partial")
+        for a in anns:
+            label = {0: "IRRELEVANT", 1: "PARTIAL", 2: "RELEVANT"}[a["relevance"]]
+            print(f"    {a['chunk_id']} (p.{a['page_number']}, sim={a['similarity_score']:.4f}) → {label}")
+
+    print(f"\n{'='*70}")
+    print("SUMMARY:")
+    print(f"  Annotated queries:  {len(annotated)}")
+    print(f"  Total chunks:       {total_chunks}")
+    print(f"  Relevant chunks:    {relevant_chunks} ({relevant_chunks/total_chunks*100:.1f}%)")
+    print(f"  Boundary splits:    {boundary_splits} queries with 2+ partial chunks")
+    print(f"{'='*70}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Annotate chunk relevance for evaluation")
+    parser.add_argument("--top-k", type=int, default=10, help="Number of chunks to retrieve per query")
+    parser.add_argument("--query-id", type=str, default=None, help="Annotate a specific query only")
+    parser.add_argument("--report", action="store_true", help="Print chunk quality report from existing annotations")
+    args = parser.parse_args()
+
+    if args.report:
+        data = load_dataset()
+        report_chunk_quality(data)
+    else:
+        run_annotation(query_id=args.query_id, top_k=args.top_k)

--- a/src/evaluation/__init__.py
+++ b/src/evaluation/__init__.py
@@ -12,8 +12,11 @@ from .rag_evaluation import (
     evaluate_rag_response,
 )
 from .retrieval_metrics import (
+    average_precision_by_pages,
     evaluate_retrieval,
     evaluate_retrieval_by_pages,
+    ndcg_at_k_by_pages,
+    ndcg_at_k_graded,
     precision_at_k,
     precision_at_k_by_pages,
     recall_at_k,
@@ -29,6 +32,9 @@ __all__ = [
     "recall_at_k",
     "precision_at_k_by_pages",
     "recall_at_k_by_pages",
+    "ndcg_at_k_by_pages",
+    "ndcg_at_k_graded",
+    "average_precision_by_pages",
     "evaluate_retrieval",
     "evaluate_retrieval_by_pages",
     "RAGEvaluationResult",

--- a/src/evaluation/evaluation_runner.py
+++ b/src/evaluation/evaluation_runner.py
@@ -8,7 +8,9 @@ from typing import Any, Callable
 from .dataset_loader import get_expected_pages, load_evaluation_dataset
 from .rag_evaluation import evaluate_rag_response
 from .retrieval_metrics import (
+    average_precision_by_pages,
     evaluate_retrieval_by_pages,
+    ndcg_at_k_by_pages,
     precision_at_k_by_pages,
     recall_at_k_by_pages,
 )
@@ -61,6 +63,9 @@ def run_full_evaluation(
 
     for q in data["queries"]:
         expected_pages = get_expected_pages(q)
+        difficulty = q.get("difficulty", "unknown")
+
+        # Skip negative queries (no expected pages) for retrieval metrics
         if not expected_pages:
             continue
 
@@ -97,6 +102,8 @@ def run_full_evaluation(
         ]
         prec = precision_at_k_by_pages(retrieved_pages, expected_pages, k)
         rec = recall_at_k_by_pages(retrieved_pages, expected_pages, k)
+        ndcg = ndcg_at_k_by_pages(retrieved_pages, expected_pages, k)
+        ap = average_precision_by_pages(retrieved_pages, expected_pages, k)
 
         result = evaluate_rag_response(
             query_id=q.get("query_id", ""),
@@ -112,8 +119,11 @@ def run_full_evaluation(
         per_query.append(
             {
                 "query_id": result.query_id,
+                "difficulty": difficulty,
                 "precision_at_k": result.precision_at_k,
                 "recall_at_k": result.recall_at_k,
+                "ndcg_at_k": ndcg,
+                "average_precision": ap,
                 "citation_coverage": result.citation_coverage,
                 "groundedness_score": result.groundedness_score,
                 "hallucination_detected": result.hallucination_detected,
@@ -125,6 +135,10 @@ def run_full_evaluation(
             hallucination_count += 1
 
     n_rag = len(per_query)
+
+    # Compute metrics by difficulty tier
+    by_difficulty = _aggregate_by_difficulty(per_query)
+
     return {
         "retrieval": retrieval_metrics,
         "rag": {
@@ -139,8 +153,33 @@ def run_full_evaluation(
             else 0.0,
             "n_queries": n_rag,
         },
+        "by_difficulty": by_difficulty,
         "per_query": per_query,
     }
+
+
+def _aggregate_by_difficulty(
+    per_query: list[dict[str, Any]],
+) -> dict[str, dict[str, float]]:
+    """Aggregate per-query metrics by difficulty tier."""
+    tiers: dict[str, list[dict[str, Any]]] = {}
+    for q in per_query:
+        tier = q.get("difficulty", "unknown")
+        tiers.setdefault(tier, []).append(q)
+
+    result: dict[str, dict[str, float]] = {}
+    for tier, queries in sorted(tiers.items()):
+        n = len(queries)
+        result[tier] = {
+            "n_queries": n,
+            "precision_at_k": round(sum(q["precision_at_k"] for q in queries) / n, 4),
+            "recall_at_k": round(sum(q["recall_at_k"] for q in queries) / n, 4),
+            "ndcg_at_k": round(sum(q["ndcg_at_k"] for q in queries) / n, 4),
+            "average_precision": round(
+                sum(q["average_precision"] for q in queries) / n, 4
+            ),
+        }
+    return result
 
 
 def export_report(results: dict[str, Any], output_path: Path) -> None:

--- a/src/evaluation/retrieval_metrics.py
+++ b/src/evaluation/retrieval_metrics.py
@@ -1,5 +1,6 @@
-"""Retrieval evaluation metrics: Precision@K and Recall@K (page-based relevance)."""
+"""Retrieval evaluation metrics: Precision@K, Recall@K, NDCG@K, MAP@K (page-based relevance)."""
 
+import math
 from pathlib import Path
 from typing import Callable
 
@@ -63,13 +64,114 @@ def recall_at_k_by_pages(
     k: int,
 ) -> float:
     """
-    Recall@K using page-based relevance.
+    Recall@K using page-based relevance (deduplicated).
+
+    Counts unique expected pages found in top-K, preventing recall > 1.0
+    when multiple chunks come from the same page.
     """
     if not expected_pages:
         return 0.0
     top_k = retrieved_pages[:k]
-    hits = sum(1 for p in top_k if p in expected_pages)
-    return hits / len(expected_pages)
+    unique_hits = len(set(top_k) & expected_pages)
+    return unique_hits / len(expected_pages)
+
+
+def ndcg_at_k_by_pages(
+    retrieved_pages: list[int],
+    expected_pages: set[int],
+    k: int,
+) -> float:
+    """
+    NDCG@K using page-based binary relevance.
+
+    Measures ranking quality: rewards relevant results appearing at higher positions.
+    Uses binary relevance (1 if page in expected_pages, 0 otherwise).
+    """
+    if k <= 0 or not expected_pages:
+        return 0.0
+
+    top_k = retrieved_pages[:k]
+
+    # DCG: sum of relevance / log2(rank + 1)
+    dcg = 0.0
+    for i, page in enumerate(top_k):
+        rel = 1.0 if page in expected_pages else 0.0
+        dcg += rel / math.log2(i + 2)  # i+2 because rank starts at 1, log2(1+1)
+
+    # Ideal DCG: all relevant results at the top
+    n_relevant = min(len(expected_pages), k)
+    idcg = sum(1.0 / math.log2(i + 2) for i in range(n_relevant))
+
+    if idcg == 0.0:
+        return 0.0
+
+    return dcg / idcg
+
+
+def average_precision_by_pages(
+    retrieved_pages: list[int],
+    expected_pages: set[int],
+    k: int,
+) -> float:
+    """
+    Average Precision@K using page-based relevance.
+
+    AP = (1/|relevant|) * sum(Precision@i * rel(i)) for i=1..K.
+    Measures both precision and ranking quality in a single metric.
+    """
+    if k <= 0 or not expected_pages:
+        return 0.0
+
+    top_k = retrieved_pages[:k]
+    hits = 0
+    sum_precision = 0.0
+
+    for i, page in enumerate(top_k):
+        if page in expected_pages:
+            hits += 1
+            sum_precision += hits / (i + 1)
+
+    if hits == 0:
+        return 0.0
+
+    return sum_precision / len(expected_pages)
+
+
+def ndcg_at_k_graded(
+    retrieved_chunk_ids: list[str],
+    chunk_annotations: list[dict],
+    k: int,
+) -> float:
+    """
+    NDCG@K using graded relevance from chunk annotations.
+
+    chunk_annotations: list of {"chunk_id": str, "relevance": int (0-2)}.
+    Uses graded relevance instead of binary, providing finer-grained ranking quality.
+    Falls back gracefully if annotations are missing.
+    """
+    if k <= 0 or not chunk_annotations:
+        return 0.0
+
+    # Build relevance lookup
+    rel_map = {a["chunk_id"]: a["relevance"] for a in chunk_annotations}
+
+    top_k = retrieved_chunk_ids[:k]
+
+    # DCG with graded relevance
+    dcg = 0.0
+    for i, cid in enumerate(top_k):
+        rel = float(rel_map.get(cid, 0))
+        dcg += rel / math.log2(i + 2)
+
+    # Ideal DCG: sort all relevance scores descending
+    all_rels = sorted([a["relevance"] for a in chunk_annotations], reverse=True)
+    ideal_rels = all_rels[:k]
+    idcg = sum(float(r) / math.log2(i + 2) for i, r in enumerate(ideal_rels))
+
+    if idcg == 0.0:
+        return 0.0
+
+    return dcg / idcg
 
 
 def evaluate_retrieval_by_pages(
@@ -81,10 +183,13 @@ def evaluate_retrieval_by_pages(
     Evaluate retriever against unified dataset using page-based relevance.
 
     retriever_fn(query) returns list of objects with .page_number and .document_id.
+    Returns Precision@K, Recall@K, NDCG@K, and MAP@K.
     """
     data = load_evaluation_dataset(dataset_path)
     precisions: list[float] = []
     recalls: list[float] = []
+    ndcgs: list[float] = []
+    avg_precisions: list[float] = []
 
     for q in data["queries"]:
         expected_pages = get_expected_pages(q)
@@ -99,14 +204,26 @@ def evaluate_retrieval_by_pages(
 
         precisions.append(precision_at_k_by_pages(retrieved_pages, expected_pages, k))
         recalls.append(recall_at_k_by_pages(retrieved_pages, expected_pages, k))
+        ndcgs.append(ndcg_at_k_by_pages(retrieved_pages, expected_pages, k))
+        avg_precisions.append(
+            average_precision_by_pages(retrieved_pages, expected_pages, k)
+        )
 
     n = len(precisions)
     if n == 0:
-        return {f"precision@{k}": 0.0, f"recall@{k}": 0.0, "n_queries": 0}
+        return {
+            f"precision@{k}": 0.0,
+            f"recall@{k}": 0.0,
+            f"ndcg@{k}": 0.0,
+            f"map@{k}": 0.0,
+            "n_queries": 0,
+        }
 
     return {
         f"precision@{k}": round(sum(precisions) / n, 4),
         f"recall@{k}": round(sum(recalls) / n, 4),
+        f"ndcg@{k}": round(sum(ndcgs) / n, 4),
+        f"map@{k}": round(sum(avg_precisions) / n, 4),
         "n_queries": n,
     }
 

--- a/src/observability/tracing.py
+++ b/src/observability/tracing.py
@@ -100,15 +100,11 @@ def trace_span(
     if openinference_span_kind and "openinference.span.kind" not in attrs:
         attrs["openinference.span.kind"] = openinference_span_kind.upper()
 
-    # Phoenix tracer accepts openinference_span_kind as kwarg for UI classification
-    kwargs: dict[str, Any] = {"attributes": attrs}
-    if openinference_span_kind:
-        kwargs["openinference_span_kind"] = openinference_span_kind.lower()
-
-    try:
-        span_ctx = tracer.start_as_current_span(name, **kwargs)
-    except TypeError:
-        span_ctx = tracer.start_as_current_span(name, attributes=attrs)
+    # Pass openinference_span_kind via attributes only.
+    # Passing it as a kwarg to start_as_current_span causes TypeError with
+    # NoOpTracer (and the error surfaces lazily when entering the context
+    # manager, making try/except unreliable).
+    span_ctx = tracer.start_as_current_span(name, attributes=attrs)
 
     with span_ctx as span:
         try:

--- a/tests/test_context_builder.py
+++ b/tests/test_context_builder.py
@@ -35,9 +35,9 @@ def test_build_context_concatenates_chunks() -> None:
         _chunk("Second chunk.", doc="d1", page=2),
     ]
     ctx = build_context(chunks, max_chunks=5)
-    assert "[d1 p.1]" in ctx
+    assert "[d1, p. 1]" in ctx
     assert "First chunk." in ctx
-    assert "[d1 p.2]" in ctx
+    assert "[d1, p. 2]" in ctx
     assert "Second chunk." in ctx
 
 

--- a/tests/test_rag_pipeline.py
+++ b/tests/test_rag_pipeline.py
@@ -76,7 +76,7 @@ def test_answer_query_returns_rag_response() -> None:
     assert "test answer" in response.answer
     assert response.context
     assert len(response.retrieved_chunks) == 1
-    assert response.citations == ["manual_dict p.5"]
+    assert response.citations == ["manual_dict, p. 5"]
 
 
 def test_answer_query_citations_deterministic() -> None:
@@ -90,8 +90,8 @@ def test_answer_query_citations_deterministic() -> None:
 
     response = answer_query("q", llm=MockLLM(), retriever=mock_retrieve)
 
-    assert "d1 p.1" in response.citations
-    assert "d1 p.2" in response.citations
+    assert "d1, p. 1" in response.citations
+    assert "d1, p. 2" in response.citations
 
 
 def test_answer_query_passes_top_k() -> None:

--- a/tests/test_retrieval_metrics.py
+++ b/tests/test_retrieval_metrics.py
@@ -6,7 +6,10 @@ from pathlib import Path
 import pytest
 
 from src.evaluation.retrieval_metrics import (
+    average_precision_by_pages,
     evaluate_retrieval,
+    ndcg_at_k_by_pages,
+    ndcg_at_k_graded,
     precision_at_k,
     precision_at_k_by_pages,
     recall_at_k,
@@ -74,6 +77,136 @@ def test_recall_at_k_by_pages() -> None:
     )
 
 
+def test_recall_at_k_by_pages_deduplicated() -> None:
+    """Recall@K must not exceed 1.0 when multiple chunks come from the same page."""
+    retrieved_pages = [122, 122, 122, 122, 122]
+    expected_pages = {122}
+    assert recall_at_k_by_pages(retrieved_pages, expected_pages, k=5) == 1.0
+
+
+def test_recall_at_k_by_pages_dedup_multiple_expected() -> None:
+    """Recall deduplication: 3 chunks from page 1, 2 from page 2, expected {1,2,3}."""
+    retrieved_pages = [1, 1, 1, 2, 2]
+    expected_pages = {1, 2, 3}
+    # unique hits: {1, 2} ∩ {1, 2, 3} = {1, 2} -> 2/3
+    assert recall_at_k_by_pages(retrieved_pages, expected_pages, k=5) == pytest.approx(
+        2 / 3
+    )
+
+
+def test_recall_at_k_by_pages_empty_expected() -> None:
+    """Recall@K = 0 when expected_pages is empty."""
+    assert recall_at_k_by_pages([1, 2, 3], set(), k=3) == 0.0
+
+
+# --- NDCG@K tests ---
+
+
+def test_ndcg_at_k_perfect_ranking() -> None:
+    """NDCG@K = 1.0 when all relevant results are at the top."""
+    retrieved_pages = [1, 2, 5, 6, 7]
+    expected_pages = {1, 2}
+    assert ndcg_at_k_by_pages(retrieved_pages, expected_pages, k=5) == pytest.approx(
+        1.0
+    )
+
+
+def test_ndcg_at_k_worst_ranking() -> None:
+    """NDCG@K < 1.0 when relevant results are at the bottom."""
+    retrieved_pages = [5, 6, 7, 1, 2]
+    expected_pages = {1, 2}
+    ndcg = ndcg_at_k_by_pages(retrieved_pages, expected_pages, k=5)
+    assert ndcg < 1.0
+    assert ndcg > 0.0
+
+
+def test_ndcg_at_k_no_relevant() -> None:
+    """NDCG@K = 0 when no relevant results."""
+    retrieved_pages = [5, 6, 7]
+    expected_pages = {1, 2}
+    assert ndcg_at_k_by_pages(retrieved_pages, expected_pages, k=3) == 0.0
+
+
+def test_ndcg_at_k_empty_expected() -> None:
+    """NDCG@K = 0 when expected_pages is empty."""
+    assert ndcg_at_k_by_pages([1, 2, 3], set(), k=3) == 0.0
+
+
+def test_ndcg_at_k_zero_k() -> None:
+    """NDCG@K = 0 when k=0."""
+    assert ndcg_at_k_by_pages([1, 2], {1}, k=0) == 0.0
+
+
+def test_ndcg_at_k_single_relevant_at_top() -> None:
+    """NDCG@K = 1.0 when the only relevant result is at position 1."""
+    retrieved_pages = [1, 5, 6]
+    expected_pages = {1}
+    assert ndcg_at_k_by_pages(retrieved_pages, expected_pages, k=3) == pytest.approx(
+        1.0
+    )
+
+
+def test_ndcg_at_k_single_relevant_at_bottom() -> None:
+    """NDCG@K < 1.0 when the only relevant result is at position 3."""
+    retrieved_pages = [5, 6, 1]
+    expected_pages = {1}
+    ndcg = ndcg_at_k_by_pages(retrieved_pages, expected_pages, k=3)
+    assert ndcg < 1.0
+    assert ndcg > 0.0
+
+
+# --- Average Precision (MAP component) tests ---
+
+
+def test_ap_perfect_ranking() -> None:
+    """AP = 1.0 when all relevant at top."""
+    retrieved_pages = [1, 2, 5, 6]
+    expected_pages = {1, 2}
+    assert average_precision_by_pages(
+        retrieved_pages, expected_pages, k=4
+    ) == pytest.approx(1.0)
+
+
+def test_ap_worst_ranking() -> None:
+    """AP < 1.0 when relevant results are at the bottom."""
+    retrieved_pages = [5, 6, 1, 2]
+    expected_pages = {1, 2}
+    ap = average_precision_by_pages(retrieved_pages, expected_pages, k=4)
+    # Position 3: prec=1/3, position 4: prec=2/4=0.5
+    # AP = (1/2) * (1/3 + 0.5) = (1/2) * (5/6) = 5/12
+    assert ap == pytest.approx(5 / 12)
+
+
+def test_ap_no_relevant() -> None:
+    """AP = 0 when no relevant results found."""
+    retrieved_pages = [5, 6, 7]
+    expected_pages = {1, 2}
+    assert average_precision_by_pages(retrieved_pages, expected_pages, k=3) == 0.0
+
+
+def test_ap_empty_expected() -> None:
+    """AP = 0 when expected_pages is empty."""
+    assert average_precision_by_pages([1, 2], set(), k=2) == 0.0
+
+
+def test_ap_zero_k() -> None:
+    """AP = 0 when k=0."""
+    assert average_precision_by_pages([1, 2], {1}, k=0) == 0.0
+
+
+def test_ap_interleaved() -> None:
+    """AP with interleaved relevant/irrelevant results."""
+    retrieved_pages = [1, 5, 2, 6]
+    expected_pages = {1, 2}
+    # Position 1: prec=1/1, position 3: prec=2/3
+    # AP = (1/2) * (1 + 2/3) = (1/2) * (5/3) = 5/6
+    ap = average_precision_by_pages(retrieved_pages, expected_pages, k=4)
+    assert ap == pytest.approx(5 / 6)
+
+
+# --- Integration tests ---
+
+
 def test_evaluate_retrieval_empty_dataset() -> None:
     """evaluate_retrieval returns zeros when no queries have expected_pages."""
     with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
@@ -89,6 +222,8 @@ def test_evaluate_retrieval_empty_dataset() -> None:
         assert metrics["n_queries"] == 0
         assert metrics["precision@5"] == 0.0
         assert metrics["recall@5"] == 0.0
+        assert metrics["ndcg@5"] == 0.0
+        assert metrics["map@5"] == 0.0
     finally:
         path.unlink()
 
@@ -109,7 +244,7 @@ def test_load_evaluation_dataset_invalid() -> None:
 
 
 def test_evaluate_retrieval_with_ground_truth() -> None:
-    """evaluate_retrieval computes metrics using expected_pages (page-based)."""
+    """evaluate_retrieval computes all metrics using expected_pages."""
     with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
         f.write("""{
             "queries": [
@@ -132,7 +267,90 @@ def test_evaluate_retrieval_with_ground_truth() -> None:
         assert metrics["n_queries"] == 1
         # Precision@2: 1/2 (only page 1 is in expected)
         assert metrics["precision@2"] == 0.5
-        # Recall@2: 1/2 (found 1 of 2 expected pages)
+        # Recall@2: 1/2 (found 1 of 2 expected pages, deduplicated)
         assert metrics["recall@2"] == 0.5
+        # NDCG and MAP should be present
+        assert "ndcg@2" in metrics
+        assert "map@2" in metrics
     finally:
         path.unlink()
+
+
+def test_evaluate_retrieval_with_duplicate_pages() -> None:
+    """evaluate_retrieval: recall is correctly deduplicated when chunks share pages."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        f.write("""{
+            "queries": [
+                {"query_id": "q1", "query": "x", "expected_pages": [122]}
+            ]
+        }""")
+        path = Path(f.name)
+
+    try:
+
+        class MockResult:
+            def __init__(self, page: int):
+                self.page_number = page
+
+        # 3 chunks from the same page — recall must be 1.0, not 3.0
+        def mock_retriever(_):
+            return [MockResult(122), MockResult(122), MockResult(122)]
+
+        metrics = evaluate_retrieval(path, mock_retriever, k=3)
+        assert metrics["recall@3"] == 1.0
+        assert metrics["recall@3"] <= 1.0  # never exceeds 1.0
+    finally:
+        path.unlink()
+
+
+# --- Graded NDCG tests ---
+
+
+def test_ndcg_graded_perfect() -> None:
+    """Graded NDCG = 1.0 when highest-relevance chunks are at the top."""
+    retrieved = ["c1", "c2", "c3"]
+    annotations = [
+        {"chunk_id": "c1", "relevance": 2},
+        {"chunk_id": "c2", "relevance": 1},
+        {"chunk_id": "c3", "relevance": 0},
+    ]
+    assert ndcg_at_k_graded(retrieved, annotations, k=3) == pytest.approx(1.0)
+
+
+def test_ndcg_graded_reversed() -> None:
+    """Graded NDCG < 1.0 when irrelevant chunks are at top."""
+    retrieved = ["c3", "c2", "c1"]
+    annotations = [
+        {"chunk_id": "c1", "relevance": 2},
+        {"chunk_id": "c2", "relevance": 1},
+        {"chunk_id": "c3", "relevance": 0},
+    ]
+    ndcg = ndcg_at_k_graded(retrieved, annotations, k=3)
+    assert ndcg < 1.0
+    assert ndcg > 0.0
+
+
+def test_ndcg_graded_no_annotations() -> None:
+    """Graded NDCG = 0 when no annotations provided."""
+    assert ndcg_at_k_graded(["c1", "c2"], [], k=2) == 0.0
+
+
+def test_ndcg_graded_unknown_chunks() -> None:
+    """Graded NDCG handles chunks not in annotations (treated as relevance=0)."""
+    retrieved = ["unknown1", "unknown2", "c1"]
+    annotations = [
+        {"chunk_id": "c1", "relevance": 2},
+    ]
+    ndcg = ndcg_at_k_graded(retrieved, annotations, k=3)
+    assert ndcg < 1.0
+    assert ndcg > 0.0
+
+
+def test_ndcg_graded_all_irrelevant() -> None:
+    """Graded NDCG = 0 when all annotations have relevance 0."""
+    retrieved = ["c1", "c2"]
+    annotations = [
+        {"chunk_id": "c1", "relevance": 0},
+        {"chunk_id": "c2", "relevance": 0},
+    ]
+    assert ndcg_at_k_graded(retrieved, annotations, k=2) == 0.0


### PR DESCRIPTION
## Summary

- Fix Recall@K deduplication bug — `recall_at_k_by_pages` was counting duplicate page hits without deduplication, producing impossible values (e.g., recall=1.5). Now uses set intersection: `len(set(top_k) & expected_pages)`
- Add NDCG@K (binary, page-based) and MAP@K (Average Precision) ranking metrics to `retrieval_metrics.py` and `evaluation_runner.py`
- Add graded NDCG@K for chunk-level relevance annotations (relevance 0/1/2)
- Expand evaluation dataset from 10 to 39 queries covering 6 topic areas (key management, fraud rules, procedural constraints, API/infrastructure, process understanding, negative queries)
- Add `difficulty` field to query schema with tiers: `single_chunk`, `multi_chunk`, `cross_section`, `negative`
- Add 4 negative queries for abstention testing (out-of-corpus topics)
- Evaluation runner now aggregates metrics by difficulty tier in report output
- Create `scripts/annotate_chunks.py` — interactive tool for chunk-level relevance labeling with quality diagnostics (boundary split detection)
- Expand test suite from ~11 to ~30 tests covering NDCG, MAP, graded NDCG, recall deduplication, and integration scenarios
- Fix NoOpTracer TypeError in `src/observability/tracing.py` — pass `openinference_span_kind` via attributes dict only, not as kwarg to `start_as_current_span()`
- Fix citation format assertions in `test_context_builder.py` and `test_rag_pipeline.py` to match actual output format `[alias, p. N]`
- Rewrite `docs/EVALUATION.md` with complete documentation of metrics, difficulty tiers, and topic coverage

## Test plan

- [x] All unit tests pass (`pytest tests/`)
- [x] Recall@K never exceeds 1.0 (verified with duplicate page scenarios)
- [x] NDCG@K and MAP@K appear in evaluation report
- [x] Evaluation runner correctly aggregates by difficulty tier
- [x] Tracing works with both Phoenix tracer and NoOpTracer
- [x] Ruff lint passes with zero errors