### PR TITLE
feat(retrieval): improve retrieval quality with similarity threshold, real tokenizer, and cross-encoder reranking

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -11,8 +11,14 @@ chunking:
   chunk_overlap: 50      # overlapping tokens between consecutive chunks
 
 retrieval:
-  top_k: 5              # number of chunks to retrieve per query
+  top_k: 10             # over-retrieve for reranking (reranker trims to top_n)
   collection: "PixRegulationChunks"
+  min_similarity: 0.35  # minimum cosine similarity to include a chunk
+
+reranking:
+  enabled: true
+  model: "cross-encoder/ms-marco-MiniLM-L-6-v2"
+  top_n: 5              # final number of chunks after reranking
 
 llm:
   model: "llama3.2:3b"

--- a/src/rag/context_builder.py
+++ b/src/rag/context_builder.py
@@ -1,55 +1,66 @@
-"""Context builder with token-based truncation."""
+"""Context builder with real-tokenizer-based greedy packing."""
 
 from typing import TYPE_CHECKING
 
 from src.utils.document_aliases import get_document_alias
+from src.utils.tokenizer import count_tokens
 
 if TYPE_CHECKING:
-    from src.retrieval.retriever import RetrievalResult
+    from src.retrieval.models import RetrievalResult
 
-CHARS_PER_TOKEN = 4
+SEPARATOR = "\n\n"
 
 
-def _count_tokens(text: str) -> int:
-    return len(text) // CHARS_PER_TOKEN
+def _format_chunk(chunk: "RetrievalResult") -> str:
+    """Format a single chunk with its source marker."""
+    alias = get_document_alias(chunk.document_id)
+    marker = f"[{alias}, p. {chunk.page_number}]"
+    return f"{marker}\n{chunk.text}"
 
 
 def build_context(
     chunks: list["RetrievalResult"],
-    max_chunks: int = 3,
+    max_chunks: int = 20,
     max_tokens: int | None = None,
 ) -> str:
     """
-    Build context string from retrieved chunks with truncation.
+    Build context string by greedily packing chunks into a token budget.
 
-    Markers use human-readable document aliases so the LLM cites correctly.
+    Chunks are added in order (highest similarity first) until the token
+    budget is exhausted. No chunk is truncated mid-text; either the whole
+    chunk fits or it is skipped.
+
+    Parameters
+    ----------
+    chunks : list[RetrievalResult]
+        Retrieved chunks, ordered by relevance (highest first).
+    max_chunks : int
+        Safety cap on number of chunks (default 20).
+    max_tokens : int | None
+        Token budget. When None, all chunks (up to max_chunks) are included.
     """
-    limited = chunks[:max_chunks]
-    parts: list[str] = []
-
-    for r in limited:
-        alias = get_document_alias(r.document_id)
-        marker = f"[{alias}, p. {r.page_number}]"
-        parts.append(f"{marker}\n{r.text}")
-
-    context = "\n\n".join(parts)
+    if not chunks:
+        return ""
 
     if max_tokens is None:
-        return context
+        limited = chunks[:max_chunks]
+        parts = [_format_chunk(c) for c in limited]
+        return SEPARATOR.join(parts)
 
-    if _count_tokens(context) <= max_tokens:
-        return context
+    parts: list[str] = []
+    total_tokens = 0
 
-    for i in range(len(limited) - 1, 0, -1):
-        truncated = "\n\n".join(parts[:i])
-        if _count_tokens(truncated) <= max_tokens:
-            return truncated
+    for chunk in chunks[:max_chunks]:
+        formatted = _format_chunk(chunk)
+        chunk_tokens = count_tokens(formatted)
 
-    if parts:
-        max_chars = max_tokens * CHARS_PER_TOKEN
-        prefix = "\n\n".join(parts[:-1])
-        sep = "\n\n" if prefix else ""
-        allowed = max_chars - len(prefix) - len(sep)
-        if allowed > 0:
-            parts[-1] = parts[-1][:allowed].rstrip() + "..."
-    return "\n\n".join(parts)
+        # Account for separator between chunks
+        sep_tokens = count_tokens(SEPARATOR) if parts else 0
+
+        if total_tokens + sep_tokens + chunk_tokens > max_tokens:
+            break
+
+        parts.append(formatted)
+        total_tokens += sep_tokens + chunk_tokens
+
+    return SEPARATOR.join(parts)

--- a/src/rag/rag_pipeline.py
+++ b/src/rag/rag_pipeline.py
@@ -68,24 +68,48 @@ class RAGResponse:
     llm_usage: LLMUsage | None = None
 
 
+def _load_config() -> dict:
+    """Load full config from config.yaml. Returns empty dict on failure."""
+    try:
+        import yaml
+        from pathlib import Path
+
+        config_path = Path(__file__).resolve().parent.parent.parent / "config" / "config.yaml"
+        if config_path.exists():
+            with open(config_path) as f:
+                return yaml.safe_load(f) or {}
+    except Exception:
+        pass
+    return {}
+
+
 def _default_retrieve(query: str, top_k: int) -> list[RetrievalResult]:
-    return retrieve(query, top_k=top_k)
+    cfg = _load_config().get("retrieval", {})
+    min_similarity = cfg.get("min_similarity", 0.0)
+    return retrieve(query, top_k=top_k, min_similarity=min_similarity)
 
 
 def answer_query(
     query: str,
     llm: LLMClient,
     top_k: int = 5,
-    max_chunks: int = 3,
-    max_context_tokens: int | None = 1500,
+    max_chunks: int = 20,
+    max_context_tokens: int | None = None,
     retriever: Callable[[str, int], list[RetrievalResult]] | None = None,
 ) -> RAGResponse:
     """
     Answer a query using RAG: retrieve → build context → prompt → generate.
 
     Returns RAGResponse with answer including citation footer for verification.
+
+    When max_context_tokens is None, the value is loaded from config.yaml
+    (rag.max_context_tokens). Falls back to 2048 if config is unavailable.
     """
     retrieve_fn = retriever or _default_retrieve
+
+    if max_context_tokens is None:
+        cfg = _load_config().get("rag", {})
+        max_context_tokens = cfg.get("max_context_tokens", 2048)
 
     with trace_span("rag_pipeline", openinference_span_kind="chain") as parent_span:
         span_set_input(parent_span, query)

--- a/src/retrieval/reranker.py
+++ b/src/retrieval/reranker.py
@@ -1,0 +1,87 @@
+"""Cross-encoder reranking for retrieval results."""
+
+import logging
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .models import RetrievalResult
+
+logger = logging.getLogger(__name__)
+
+_cross_encoder = None
+
+
+def _get_cross_encoder(model_name: str):
+    """Load and cache cross-encoder model. Returns None on failure."""
+    global _cross_encoder
+    if _cross_encoder is not None:
+        return _cross_encoder
+    try:
+        from sentence_transformers import CrossEncoder
+
+        _cross_encoder = CrossEncoder(model_name)
+        logger.info("Loaded cross-encoder model: %s", model_name)
+        return _cross_encoder
+    except Exception as e:
+        logger.warning("Failed to load cross-encoder '%s': %s", model_name, e)
+        return None
+
+
+def rerank(
+    query: str,
+    chunks: list["RetrievalResult"],
+    model_name: str = "cross-encoder/ms-marco-MiniLM-L-6-v2",
+    top_n: int = 5,
+) -> list["RetrievalResult"]:
+    """
+    Rerank chunks using a cross-encoder model.
+
+    Graceful degradation: if cross-encoder is unavailable or prediction
+    fails, returns chunks[:top_n] with original ordering.
+
+    Parameters
+    ----------
+    query : str
+        The user query.
+    chunks : list[RetrievalResult]
+        Chunks from initial retrieval (ordered by vector similarity).
+    model_name : str
+        HuggingFace model identifier for the cross-encoder.
+    top_n : int
+        Number of top results to return after reranking.
+
+    Returns
+    -------
+    list[RetrievalResult]
+        Reranked chunks, ordered by cross-encoder score (highest first).
+    """
+    if not chunks:
+        return []
+
+    encoder = _get_cross_encoder(model_name)
+    if encoder is None:
+        logger.info(
+            "Cross-encoder unavailable; returning top-%d by vector similarity.", top_n,
+        )
+        return chunks[:top_n]
+
+    pairs = [(query, chunk.text) for chunk in chunks]
+
+    try:
+        scores = encoder.predict(pairs)
+    except Exception as e:
+        logger.warning("Cross-encoder prediction failed: %s. Falling back.", e)
+        return chunks[:top_n]
+
+    scored = sorted(
+        zip(chunks, scores), key=lambda x: float(x[1]), reverse=True,
+    )
+
+    reranked = []
+    for chunk, score in scored[:top_n]:
+        reranked.append(
+            replace(chunk, similarity_score=round(float(score), 4))
+        )
+
+    return reranked

--- a/src/retrieval/retriever.py
+++ b/src/retrieval/retriever.py
@@ -1,28 +1,60 @@
-"""Retriever orchestration: query embedding + vector search."""
+"""Retriever orchestration: query embedding + vector search + optional reranking."""
+
+import logging
+from pathlib import Path
 
 from .models import RetrievalResult
 from .query_embedding import embed_query
 from .vector_search import vector_search
 
+logger = logging.getLogger(__name__)
+
+
+def _load_reranking_config() -> dict:
+    """Load reranking config from config.yaml. Returns empty dict on failure."""
+    try:
+        import yaml
+
+        config_path = Path(__file__).resolve().parent.parent.parent / "config" / "config.yaml"
+        if config_path.exists():
+            with open(config_path) as f:
+                cfg = yaml.safe_load(f)
+            return cfg.get("reranking", {})
+    except Exception:
+        pass
+    return {}
+
 
 def retrieve(
     query: str,
     top_k: int = 5,
+    min_similarity: float = 0.0,
 ) -> list[RetrievalResult]:
     """
     Retrieve top-K most relevant chunks for a query.
 
-    Pipeline: query → embed_query → vector_search → RetrievalResult list.
+    Pipeline: query → embed → vector_search → [optional rerank] → results.
+
+    When reranking is enabled via config, over-retrieves (top_k * 2) from
+    vector search then reranks down to top_k.
 
     Returns
     -------
     list[RetrievalResult]
-        Ranked retrieval results ordered by similarity score (highest first).
+        Ranked retrieval results ordered by similarity/relevance score.
     """
-    query_vector = embed_query(query)
-    raw_results = vector_search(query_vector, top_k=top_k)
+    rerank_cfg = _load_reranking_config()
+    reranking_enabled = rerank_cfg.get("enabled", False)
 
-    return [
+    # Over-retrieve when reranking to give cross-encoder more candidates
+    fetch_k = top_k * 2 if reranking_enabled else top_k
+
+    query_vector = embed_query(query)
+    raw_results = vector_search(
+        query_vector, top_k=fetch_k, min_similarity=min_similarity,
+    )
+
+    results = [
         RetrievalResult(
             text=r.get("text") or "",
             chunk_id=r.get("chunk_id") or "",
@@ -34,3 +66,16 @@ def retrieve(
         )
         for r in raw_results
     ]
+
+    if reranking_enabled and results:
+        from .reranker import rerank
+
+        model_name = rerank_cfg.get("model", "cross-encoder/ms-marco-MiniLM-L-6-v2")
+        top_n = rerank_cfg.get("top_n", top_k)
+        logger.info(
+            "Reranking %d candidates → top %d with %s",
+            len(results), top_n, model_name,
+        )
+        results = rerank(query, results, model_name=model_name, top_n=top_n)
+
+    return results

--- a/src/retrieval/vector_search.py
+++ b/src/retrieval/vector_search.py
@@ -9,6 +9,7 @@ from src.vectorstore.weaviate_client import CHUNK_COLLECTION, get_weaviate_clien
 def vector_search(
     query_vector: list[float],
     top_k: int = 5,
+    min_similarity: float = 0.0,
 ) -> list[dict[str, Any]]:
     """
     Execute vector similarity search in Weaviate.
@@ -52,5 +53,12 @@ def vector_search(
                 "similarity_score": similarity,
             }
         )
+
+    if min_similarity > 0.0:
+        results = [
+            r for r in results
+            if r["similarity_score"] is not None
+            and r["similarity_score"] >= min_similarity
+        ]
 
     return results

--- a/src/utils/tokenizer.py
+++ b/src/utils/tokenizer.py
@@ -1,0 +1,20 @@
+"""Shared tokenizer utilities for token counting across the project."""
+
+from transformers import AutoTokenizer
+
+DEFAULT_MODEL = "BAAI/bge-m3"
+
+_tokenizer_cache: dict[str, AutoTokenizer] = {}
+
+
+def get_tokenizer(model_name: str = DEFAULT_MODEL) -> AutoTokenizer:
+    """Return cached tokenizer instance."""
+    if model_name not in _tokenizer_cache:
+        _tokenizer_cache[model_name] = AutoTokenizer.from_pretrained(model_name)
+    return _tokenizer_cache[model_name]
+
+
+def count_tokens(text: str, model_name: str = DEFAULT_MODEL) -> int:
+    """Count tokens in text using the actual tokenizer."""
+    tokenizer = get_tokenizer(model_name)
+    return len(tokenizer.encode(text, add_special_tokens=False))

--- a/tests/test_context_builder.py
+++ b/tests/test_context_builder.py
@@ -1,8 +1,7 @@
 """Unit tests for RAG context builder."""
 
 from dataclasses import dataclass
-
-from src.rag.context_builder import build_context
+from unittest.mock import patch
 
 
 @dataclass
@@ -28,44 +27,82 @@ def _chunk(text: str, doc: str = "manual_dict", page: int = 1) -> _RetrievalResu
     )
 
 
+def _mock_count(text: str, model_name: str = "BAAI/bge-m3") -> int:
+    """Simple mock: 1 token per character for predictable tests."""
+    return len(text)
+
+
 def test_build_context_concatenates_chunks() -> None:
     """Context joins chunk texts with markers."""
-    chunks: list[_RetrievalResult] = [
-        _chunk("First chunk.", doc="d1", page=1),
-        _chunk("Second chunk.", doc="d1", page=2),
-    ]
-    ctx = build_context(chunks, max_chunks=5)
-    assert "[d1, p. 1]" in ctx
-    assert "First chunk." in ctx
-    assert "[d1, p. 2]" in ctx
-    assert "Second chunk." in ctx
+    with patch("src.rag.context_builder.count_tokens", side_effect=_mock_count):
+        from src.rag.context_builder import build_context
+
+        chunks = [
+            _chunk("First chunk.", doc="d1", page=1),
+            _chunk("Second chunk.", doc="d1", page=2),
+        ]
+        ctx = build_context(chunks, max_chunks=5)
+        assert "[d1, p. 1]" in ctx
+        assert "First chunk." in ctx
+        assert "[d1, p. 2]" in ctx
+        assert "Second chunk." in ctx
 
 
 def test_build_context_respects_max_chunks() -> None:
     """Only first max_chunks are included."""
-    chunks = [_chunk(f"Chunk {i}.", page=i) for i in range(1, 8)]
-    ctx = build_context(chunks, max_chunks=3)
-    assert "Chunk 1." in ctx
-    assert "Chunk 2." in ctx
-    assert "Chunk 3." in ctx
-    assert "Chunk 4." not in ctx
+    with patch("src.rag.context_builder.count_tokens", side_effect=_mock_count):
+        from src.rag.context_builder import build_context
+
+        chunks = [_chunk(f"Chunk {i}.", page=i) for i in range(1, 8)]
+        ctx = build_context(chunks, max_chunks=3)
+        assert "Chunk 1." in ctx
+        assert "Chunk 2." in ctx
+        assert "Chunk 3." in ctx
+        assert "Chunk 4." not in ctx
 
 
-def test_build_context_truncates_by_tokens() -> None:
-    """When over max_tokens, truncates oldest chunks."""
-    # ~4 chars per token, so 100 chars ≈ 25 tokens
-    long_text = "x" * 200  # ~50 tokens
-    chunks = [
-        _chunk("short", page=1),
-        _chunk(long_text, page=2),
-    ]
-    ctx = build_context(chunks, max_chunks=5, max_tokens=30)
-    # Should fit "short" + marker + some of long_text, or truncate
-    assert len(ctx) <= 30 * 4 + 50  # rough upper bound
+def test_build_context_greedy_packing_stops_at_budget() -> None:
+    """Greedy packing stops when next chunk would exceed token budget."""
+    with patch("src.rag.context_builder.count_tokens", side_effect=_mock_count):
+        from src.rag.context_builder import build_context
+
+        # Each formatted chunk: "[manual_dict, p. N]\ntext" + separator "\n\n"
+        # With mock count, tokens = len(formatted_text)
+        chunks = [
+            _chunk("A" * 50, page=1),   # ~70 chars with marker
+            _chunk("B" * 50, page=2),   # ~70 chars with marker
+            _chunk("C" * 50, page=3),   # ~70 chars with marker
+        ]
+        # Budget that fits 2 chunks but not 3
+        ctx = build_context(chunks, max_tokens=160)
+        assert "A" * 50 in ctx
+        assert "B" * 50 in ctx
+        assert "C" * 50 not in ctx
+
+
+def test_build_context_skips_chunk_exceeding_budget() -> None:
+    """When a single chunk exceeds the entire budget, no chunks are included."""
+    with patch("src.rag.context_builder.count_tokens", side_effect=_mock_count):
+        from src.rag.context_builder import build_context
+
+        chunks = [_chunk("X" * 500, page=1)]
+        ctx = build_context(chunks, max_tokens=10)
+        assert ctx == ""
 
 
 def test_build_context_no_truncation_when_under_limit() -> None:
     """Full context when under max_tokens."""
-    chunks = [_chunk("A"), _chunk("B")]
-    ctx = build_context(chunks, max_chunks=5, max_tokens=1000)
-    assert "A" in ctx and "B" in ctx
+    with patch("src.rag.context_builder.count_tokens", side_effect=_mock_count):
+        from src.rag.context_builder import build_context
+
+        chunks = [_chunk("A"), _chunk("B")]
+        ctx = build_context(chunks, max_chunks=5, max_tokens=1000)
+        assert "A" in ctx and "B" in ctx
+
+
+def test_build_context_empty_chunks() -> None:
+    """Empty chunks list returns empty string."""
+    with patch("src.rag.context_builder.count_tokens", side_effect=_mock_count):
+        from src.rag.context_builder import build_context
+
+        assert build_context([], max_tokens=100) == ""

--- a/tests/test_rag_pipeline.py
+++ b/tests/test_rag_pipeline.py
@@ -68,6 +68,7 @@ def test_answer_query_returns_rag_response() -> None:
     response = answer_query(
         "Como cadastrar chave?",
         llm=MockLLM(),
+        max_context_tokens=1500,
         retriever=_mock_retrieve,
     )
 
@@ -88,7 +89,9 @@ def test_answer_query_citations_deterministic() -> None:
             _chunk("B", doc="d1", page=2),
         ]
 
-    response = answer_query("q", llm=MockLLM(), retriever=mock_retrieve)
+    response = answer_query(
+        "q", llm=MockLLM(), max_context_tokens=1500, retriever=mock_retrieve,
+    )
 
     assert "d1, p. 1" in response.citations
     assert "d1, p. 2" in response.citations
@@ -102,7 +105,9 @@ def test_answer_query_passes_top_k() -> None:
         calls.append((query, top_k))
         return []
 
-    answer_query("q", llm=MockLLM(), top_k=7, retriever=mock_retrieve)
+    answer_query(
+        "q", llm=MockLLM(), top_k=7, max_context_tokens=1500, retriever=mock_retrieve,
+    )
 
     assert calls == [("q", 7)]
 

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -1,0 +1,124 @@
+"""Unit tests for cross-encoder reranker."""
+
+from dataclasses import dataclass
+from unittest.mock import MagicMock, patch
+
+
+@dataclass
+class _RetrievalResult:
+    """Minimal RetrievalResult for tests (avoids heavy imports)."""
+    text: str
+    chunk_id: str
+    document_id: str
+    page_number: int
+    section_title: str | None
+    similarity_score: float | None
+    source_file: str | None = None
+
+
+def _chunk(
+    text: str = "chunk text",
+    chunk_id: str = "c1",
+    score: float = 0.5,
+    page: int = 1,
+) -> _RetrievalResult:
+    return _RetrievalResult(
+        text=text,
+        chunk_id=chunk_id,
+        document_id="doc",
+        page_number=page,
+        section_title=None,
+        similarity_score=score,
+    )
+
+
+def test_rerank_reorders_by_cross_encoder_score() -> None:
+    """Cross-encoder scores should determine final ordering."""
+    chunks = [_chunk(chunk_id="c1"), _chunk(chunk_id="c2"), _chunk(chunk_id="c3")]
+    mock_encoder = MagicMock()
+    mock_encoder.predict.return_value = [0.1, 0.9, 0.5]  # c2 is best
+
+    with patch("src.retrieval.reranker._get_cross_encoder", return_value=mock_encoder):
+        from src.retrieval.reranker import rerank
+
+        result = rerank("query", chunks, top_n=2)
+
+    assert len(result) == 2
+    assert result[0].chunk_id == "c2"  # highest score (0.9)
+    assert result[1].chunk_id == "c3"  # second highest (0.5)
+
+
+def test_rerank_updates_similarity_score() -> None:
+    """Reranked results should have cross-encoder scores, not original similarity."""
+    chunks = [_chunk(chunk_id="c1", score=0.8)]
+    mock_encoder = MagicMock()
+    mock_encoder.predict.return_value = [2.5]
+
+    with patch("src.retrieval.reranker._get_cross_encoder", return_value=mock_encoder):
+        from src.retrieval.reranker import rerank
+
+        result = rerank("query", chunks, top_n=1)
+
+    assert result[0].similarity_score == 2.5
+
+
+def test_rerank_graceful_degradation_model_unavailable() -> None:
+    """When cross-encoder fails to load, return original top_n."""
+    chunks = [_chunk(chunk_id="c1"), _chunk(chunk_id="c2")]
+
+    with patch("src.retrieval.reranker._get_cross_encoder", return_value=None):
+        from src.retrieval.reranker import rerank
+
+        result = rerank("query", chunks, top_n=1)
+
+    assert len(result) == 1
+    assert result[0].chunk_id == "c1"  # original order preserved
+
+
+def test_rerank_graceful_degradation_predict_failure() -> None:
+    """When prediction fails, return original top_n."""
+    chunks = [_chunk(chunk_id="c1"), _chunk(chunk_id="c2")]
+    mock_encoder = MagicMock()
+    mock_encoder.predict.side_effect = RuntimeError("CUDA OOM")
+
+    with patch("src.retrieval.reranker._get_cross_encoder", return_value=mock_encoder):
+        from src.retrieval.reranker import rerank
+
+        result = rerank("query", chunks, top_n=2)
+
+    assert len(result) == 2
+
+
+def test_rerank_empty_chunks() -> None:
+    """Empty input returns empty output."""
+    from src.retrieval.reranker import rerank
+
+    assert rerank("query", [], top_n=5) == []
+
+
+def test_rerank_preserves_metadata() -> None:
+    """Reranked results should preserve all fields except similarity_score."""
+    chunk = _RetrievalResult(
+        text="important text",
+        chunk_id="c42",
+        document_id="manual_dict",
+        page_number=7,
+        section_title="Section A",
+        similarity_score=0.8,
+        source_file="doc.pdf",
+    )
+    mock_encoder = MagicMock()
+    mock_encoder.predict.return_value = [1.5]
+
+    with patch("src.retrieval.reranker._get_cross_encoder", return_value=mock_encoder):
+        from src.retrieval.reranker import rerank
+
+        result = rerank("query", [chunk], top_n=1)
+
+    assert result[0].chunk_id == "c42"
+    assert result[0].document_id == "manual_dict"
+    assert result[0].page_number == 7
+    assert result[0].section_title == "Section A"
+    assert result[0].source_file == "doc.pdf"
+    assert result[0].text == "important text"
+    assert result[0].similarity_score == 1.5  # updated to cross-encoder score

--- a/tests/test_similarity_filter.py
+++ b/tests/test_similarity_filter.py
@@ -1,0 +1,96 @@
+"""Unit tests for minimum similarity threshold filtering."""
+
+from unittest.mock import MagicMock, patch
+
+
+def _make_weaviate_obj(chunk_id: str, distance: float | None) -> MagicMock:
+    """Create a mock Weaviate response object with given distance."""
+    obj = MagicMock()
+    obj.properties = {
+        "chunk_id": chunk_id,
+        "document_id": "doc",
+        "page_number": 1,
+        "section_title": None,
+        "text": f"text for {chunk_id}",
+        "source_file": "test.pdf",
+    }
+    obj.metadata.distance = distance
+    return obj
+
+
+def _mock_vector_search(objects: list[MagicMock], **kwargs):
+    """Run vector_search with mocked Weaviate client."""
+    mock_response = MagicMock()
+    mock_response.objects = objects
+
+    mock_collection = MagicMock()
+    mock_collection.query.near_vector.return_value = mock_response
+
+    mock_client = MagicMock()
+    mock_client.collections.get.return_value = mock_collection
+
+    dummy_vector = [0.0] * 1024
+
+    with patch("src.retrieval.vector_search.get_weaviate_client", return_value=mock_client):
+        from src.retrieval.vector_search import vector_search
+
+        return vector_search(dummy_vector, **kwargs)
+
+
+def test_min_similarity_filters_low_scores() -> None:
+    """Only chunks above min_similarity are returned."""
+    objects = [
+        _make_weaviate_obj("c1", distance=0.1),  # similarity = 0.9
+        _make_weaviate_obj("c2", distance=0.5),  # similarity = 0.5
+        _make_weaviate_obj("c3", distance=0.8),  # similarity = 0.2
+    ]
+    results = _mock_vector_search(objects, top_k=5, min_similarity=0.4)
+    assert len(results) == 2
+    assert results[0]["chunk_id"] == "c1"
+    assert results[1]["chunk_id"] == "c2"
+
+
+def test_min_similarity_zero_passes_all() -> None:
+    """With min_similarity=0.0, all results pass through."""
+    objects = [
+        _make_weaviate_obj("c1", distance=0.1),
+        _make_weaviate_obj("c2", distance=0.9),
+    ]
+    results = _mock_vector_search(objects, top_k=5, min_similarity=0.0)
+    assert len(results) == 2
+
+
+def test_min_similarity_returns_empty_when_all_below() -> None:
+    """When all scores are below threshold, return empty list."""
+    objects = [
+        _make_weaviate_obj("c1", distance=0.8),  # similarity = 0.2
+        _make_weaviate_obj("c2", distance=0.9),  # similarity = 0.1
+    ]
+    results = _mock_vector_search(objects, top_k=5, min_similarity=0.5)
+    assert len(results) == 0
+
+
+def test_min_similarity_excludes_none_scores() -> None:
+    """Chunks with similarity_score=None are excluded when threshold > 0."""
+    obj = MagicMock()
+    obj.properties = {
+        "chunk_id": "c1",
+        "document_id": "doc",
+        "page_number": 1,
+        "section_title": None,
+        "text": "text",
+        "source_file": "test.pdf",
+    }
+    obj.metadata.distance = None  # no distance available
+
+    results = _mock_vector_search([obj], top_k=5, min_similarity=0.3)
+    assert len(results) == 0
+
+
+def test_min_similarity_default_preserves_backward_compatibility() -> None:
+    """Default min_similarity=0.0 preserves original behavior."""
+    objects = [
+        _make_weaviate_obj("c1", distance=0.99),  # similarity = 0.01
+    ]
+    results = _mock_vector_search(objects, top_k=5)
+    assert len(results) == 1

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -1,0 +1,46 @@
+"""Unit tests for shared tokenizer utility."""
+
+import pytest
+
+
+@pytest.mark.slow
+def test_count_tokens_returns_positive_int() -> None:
+    """count_tokens returns a positive integer for non-empty text."""
+    from src.utils.tokenizer import count_tokens
+
+    result = count_tokens("hello world")
+    assert isinstance(result, int)
+    assert result > 0
+
+
+@pytest.mark.slow
+def test_count_tokens_empty_string() -> None:
+    """count_tokens returns 0 for empty string."""
+    from src.utils.tokenizer import count_tokens
+
+    assert count_tokens("") == 0
+
+
+@pytest.mark.slow
+def test_count_tokens_consistent() -> None:
+    """Same text returns same count across calls."""
+    from src.utils.tokenizer import count_tokens
+
+    text = "O cadastro de chave Pix é feito pelo participante."
+    assert count_tokens(text) == count_tokens(text)
+
+
+@pytest.mark.slow
+def test_count_tokens_portuguese_accuracy() -> None:
+    """Token count for Portuguese text is reasonable (not heuristic)."""
+    from src.utils.tokenizer import count_tokens
+
+    # 100 chars of Portuguese text; heuristic would say ~25 tokens (100/4)
+    # Real tokenizer should give a different count
+    text = "O participante deve registrar a chave Pix no DICT conforme regulamentação vigente do BCB."
+    tokens = count_tokens(text)
+    assert tokens > 0
+    # Real tokenizer count should differ from len(text) // 4
+    heuristic = len(text) // 4
+    # Just verify it's a reasonable number (not wildly off)
+    assert tokens != heuristic or tokens > 10  # sanity check


### PR DESCRIPTION
Issue 2.1 — Minimum similarity threshold:
- Add min_similarity parameter to vector_search() and retrieve()
- Filter chunks below threshold (default 0.35 via config.yaml)
- Queries with no relevant chunks produce abstention naturally

Issue 2.2 — Real tokenizer in context builder:
- Create src/utils/tokenizer.py wrapping BGE-M3 AutoTokenizer
- Rewrite context_builder.py: greedy packing with real token count,
  no mid-chunk truncation, max_chunks raised from 3 to 20
- Fix silent config bug: max_context_tokens was 1500 in code vs 4096
  in config.yaml — now loads from config with 2048 fallback

Issue 2.3 — Cross-encoder reranking:
- Create src/retrieval/reranker.py with graceful degradation
- Retrieve top_k*2 candidates, rerank to top_n with cross-encoder
- Model: cross-encoder/ms-marco-MiniLM-L-6-v2 (configurable)
- Optional via config flag (reranking.enabled)

Tests: 18 new unit tests across 4 new test files + updated existing tests.