### PR TITLE
feat(retrieval): add BM25 and hybrid search with configurable strategy

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -13,7 +13,11 @@ chunking:
 retrieval:
   top_k: 10             # over-retrieve for reranking (reranker trims to top_n)
   collection: "PixRegulationChunks"
-  min_similarity: 0.35  # minimum cosine similarity to include a chunk
+  min_similarity: 0.35  # minimum cosine similarity (vector strategy only)
+  search_strategy: "hybrid"  # "vector" | "keyword" | "hybrid"
+  hybrid:
+    alpha: 0.5           # 0.0 = pure BM25, 1.0 = pure vector
+    fusion_type: "ranked" # "ranked" (RRF) or "relative_score"
 
 reranking:
   enabled: true

--- a/scripts/compare_search_strategies.py
+++ b/scripts/compare_search_strategies.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+"""
+Compare retrieval strategies: vector, keyword, and hybrid (with alpha sweep).
+
+Run from project root (after run_indexing.py):
+
+    python scripts/compare_search_strategies.py
+"""
+
+import json
+import logging
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.evaluation.evaluation_runner import run_retrieval_evaluation  # noqa: E402
+from src.retrieval import retrieve  # noqa: E402
+from src.utils.system_checks import check_evaluation_dependencies  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s | %(message)s")
+logger = logging.getLogger(__name__)
+
+DATASET_PATH = PROJECT_ROOT / "data" / "evaluation" / "rag_evaluation_dataset.json"
+REPORTS_DIR = PROJECT_ROOT / "reports"
+DEFAULT_K = 5
+
+# Strategies to compare: (label, strategy, alpha)
+STRATEGIES = [
+    ("vector", "vector", None),
+    ("keyword (BM25)", "keyword", None),
+    ("hybrid α=0.25", "hybrid", 0.25),
+    ("hybrid α=0.50", "hybrid", 0.50),
+    ("hybrid α=0.75", "hybrid", 0.75),
+]
+
+
+def main() -> None:
+    """Run evaluation for each strategy and produce comparison table."""
+    if not DATASET_PATH.exists():
+        logger.error("Dataset not found: %s", DATASET_PATH)
+        raise SystemExit(1)
+
+    ready, msg = check_evaluation_dependencies()
+    if not ready:
+        logger.error("%s", msg)
+        raise SystemExit(1)
+
+    all_results: dict[str, dict] = {}
+
+    for label, strategy, alpha in STRATEGIES:
+        logger.info("=" * 60)
+        logger.info("Evaluating: %s", label)
+        logger.info("=" * 60)
+
+        def retriever_fn(query: str, _s=strategy, _a=alpha):
+            return retrieve(query, top_k=DEFAULT_K, search_strategy=_s, alpha=_a)
+
+        metrics = run_retrieval_evaluation(DATASET_PATH, retriever_fn, k=DEFAULT_K)
+        all_results[label] = metrics
+
+        logger.info(
+            "%s → P@%d=%.4f  R@%d=%.4f  NDCG@%d=%.4f  MAP@%d=%.4f  (n=%d)",
+            label,
+            DEFAULT_K, metrics.get(f"precision@{DEFAULT_K}", 0),
+            DEFAULT_K, metrics.get(f"recall@{DEFAULT_K}", 0),
+            DEFAULT_K, metrics.get(f"ndcg@{DEFAULT_K}", 0),
+            DEFAULT_K, metrics.get(f"map@{DEFAULT_K}", 0),
+            metrics.get("n_queries", 0),
+        )
+
+    # Print comparison table
+    print("\n" + "=" * 80)
+    print(f"{'Strategy':<20} {'P@5':>8} {'R@5':>8} {'NDCG@5':>8} {'MAP@5':>8} {'Queries':>8}")
+    print("-" * 80)
+    for label in all_results:
+        m = all_results[label]
+        print(
+            f"{label:<20} {m.get(f'precision@{DEFAULT_K}', 0):>8.4f} "
+            f"{m.get(f'recall@{DEFAULT_K}', 0):>8.4f} "
+            f"{m.get(f'ndcg@{DEFAULT_K}', 0):>8.4f} "
+            f"{m.get(f'map@{DEFAULT_K}', 0):>8.4f} "
+            f"{m.get('n_queries', 0):>8d}"
+        )
+    print("=" * 80)
+
+    # Export report
+    REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+    report_path = REPORTS_DIR / "strategy_comparison.json"
+    with open(report_path, "w", encoding="utf-8") as f:
+        json.dump(all_results, f, indent=2, ensure_ascii=False)
+    logger.info("Report saved to %s", report_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/evaluate_retrieval.py
+++ b/scripts/evaluate_retrieval.py
@@ -5,8 +5,12 @@ Evaluate retrieval system against evaluation dataset.
 Run from project root (after run_indexing.py):
 
     python scripts/evaluate_retrieval.py
+    python scripts/evaluate_retrieval.py --strategy hybrid
+    python scripts/evaluate_retrieval.py --strategy vector
+    python scripts/evaluate_retrieval.py --strategy keyword
 """
 
+import argparse
 import logging
 import sys
 from pathlib import Path
@@ -27,6 +31,15 @@ DEFAULT_K = 5
 
 def main() -> None:
     """Run retrieval evaluation and display metrics."""
+    parser = argparse.ArgumentParser(description="Evaluate retrieval system")
+    parser.add_argument(
+        "--strategy",
+        choices=["vector", "keyword", "hybrid"],
+        default=None,
+        help="Search strategy override (default: use config.yaml)",
+    )
+    args = parser.parse_args()
+
     if not DATASET_PATH.exists():
         logger.error("Dataset not found: %s", DATASET_PATH)
         raise SystemExit(1)
@@ -36,17 +49,21 @@ def main() -> None:
         logger.error("%s", msg)
         raise SystemExit(1)
 
+    strategy_label = args.strategy or "config default"
+
     def retriever_fn(query: str):
-        return retrieve(query, top_k=DEFAULT_K)
+        return retrieve(query, top_k=DEFAULT_K, search_strategy=args.strategy)
 
     metrics = run_retrieval_evaluation(DATASET_PATH, retriever_fn, k=DEFAULT_K)
 
-    logger.info("Retrieval evaluation (k=%d)", DEFAULT_K)
+    logger.info("Retrieval evaluation (k=%d, strategy=%s)", DEFAULT_K, strategy_label)
     logger.info("Queries evaluated: %d", metrics.get("n_queries", 0))
     logger.info(
         "Precision@%d = %.4f", DEFAULT_K, metrics.get(f"precision@{DEFAULT_K}", 0)
     )
     logger.info("Recall@%d = %.4f", DEFAULT_K, metrics.get(f"recall@{DEFAULT_K}", 0))
+    logger.info("NDCG@%d = %.4f", DEFAULT_K, metrics.get(f"ndcg@{DEFAULT_K}", 0))
+    logger.info("MAP@%d = %.4f", DEFAULT_K, metrics.get(f"map@{DEFAULT_K}", 0))
 
     if metrics.get("n_queries", 0) == 0:
         logger.warning(

--- a/src/retrieval/__init__.py
+++ b/src/retrieval/__init__.py
@@ -5,13 +5,15 @@ from .models import RetrievalResult
 __all__ = [
     "embed_query",
     "vector_search",
+    "keyword_search",
+    "hybrid_search",
     "retrieve",
     "RetrievalResult",
 ]
 
 
 def __getattr__(name: str):
-    """Lazy import for heavy modules (embed_query, retrieve, vector_search)."""
+    """Lazy import for heavy modules (embed_query, retrieve, vector_search, etc.)."""
     if name == "embed_query":
         from .query_embedding import embed_query
         return embed_query
@@ -21,4 +23,10 @@ def __getattr__(name: str):
     if name == "vector_search":
         from .vector_search import vector_search
         return vector_search
+    if name == "keyword_search":
+        from .keyword_search import keyword_search
+        return keyword_search
+    if name == "hybrid_search":
+        from .hybrid_search import hybrid_search
+        return hybrid_search
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/retrieval/hybrid_search.py
+++ b/src/retrieval/hybrid_search.py
@@ -1,0 +1,101 @@
+"""Hybrid search (BM25 + vector) over indexed regulatory chunks."""
+
+import logging
+from typing import Any
+
+from weaviate.classes.query import HybridFusion
+
+from src.vectorstore.weaviate_client import BGE_M3_DIMENSIONS, CHUNK_COLLECTION, get_weaviate_client
+
+logger = logging.getLogger(__name__)
+
+FUSION_TYPES = {
+    "ranked": HybridFusion.RANKED,
+    "relative_score": HybridFusion.RELATIVE_SCORE,
+}
+
+
+def hybrid_search(
+    query: str,
+    query_vector: list[float],
+    top_k: int = 5,
+    alpha: float = 0.5,
+    fusion_type: str = "ranked",
+) -> list[dict[str, Any]]:
+    """
+    Execute hybrid search (BM25 + vector) in Weaviate.
+
+    Combines keyword (BM25) and semantic (vector) search using Weaviate's
+    native hybrid query. The alpha parameter controls the balance:
+    0.0 = pure BM25, 1.0 = pure vector, 0.5 = equal weight.
+
+    Parameters
+    ----------
+    query : str
+        The search query string (used for BM25 component).
+    query_vector : list[float]
+        Pre-computed query embedding (used for vector component).
+    top_k : int
+        Maximum number of results to return.
+    alpha : float
+        Balance between BM25 and vector search (0.0 to 1.0).
+    fusion_type : str
+        Score fusion strategy: "ranked" (RRF) or "relative_score".
+
+    Returns
+    -------
+    list[dict[str, Any]]
+        Results with same structure as vector_search for compatibility.
+    """
+    if len(query_vector) != BGE_M3_DIMENSIONS:
+        raise ValueError(
+            f"Invalid embedding dimension: expected {BGE_M3_DIMENSIONS}, "
+            f"got {len(query_vector)}"
+        )
+
+    if not 0.0 <= alpha <= 1.0:
+        raise ValueError(
+            f"alpha must be between 0.0 and 1.0, got {alpha}"
+        )
+
+    fusion_enum = FUSION_TYPES.get(fusion_type)
+    if fusion_enum is None:
+        raise ValueError(
+            f"Invalid fusion_type: {fusion_type!r}. "
+            f"Must be one of: {list(FUSION_TYPES.keys())}"
+        )
+
+    client = get_weaviate_client()
+    collection = client.collections.get(CHUNK_COLLECTION)
+
+    response = collection.query.hybrid(
+        query=query,
+        vector=query_vector,
+        alpha=alpha,
+        fusion_type=fusion_enum,
+        limit=top_k,
+        return_metadata=["score"],
+    )
+
+    results: list[dict[str, Any]] = []
+    for obj in response.objects:
+        props = obj.properties
+        score = (
+            getattr(obj.metadata, "score", None)
+            if hasattr(obj, "metadata")
+            else None
+        )
+
+        results.append(
+            {
+                "chunk_id": props.get("chunk_id"),
+                "document_id": props.get("document_id"),
+                "page_number": props.get("page_number"),
+                "section_title": props.get("section_title"),
+                "text": props.get("text"),
+                "source_file": props.get("source_file"),
+                "similarity_score": round(float(score), 4) if score is not None else None,
+            }
+        )
+
+    return results

--- a/src/retrieval/keyword_search.py
+++ b/src/retrieval/keyword_search.py
@@ -1,0 +1,72 @@
+"""BM25 keyword search over indexed regulatory chunks."""
+
+import logging
+from typing import Any
+
+from src.vectorstore.weaviate_client import CHUNK_COLLECTION, get_weaviate_client
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_QUERY_PROPERTIES = ["text"]
+
+
+def keyword_search(
+    query: str,
+    top_k: int = 5,
+    query_properties: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    """
+    Execute BM25 keyword search in Weaviate.
+
+    Uses Weaviate's native BM25 index (enabled by default on TEXT properties).
+    Returns list of results with metadata and BM25 score.
+
+    Parameters
+    ----------
+    query : str
+        The search query string for BM25 matching.
+    top_k : int
+        Maximum number of results to return.
+    query_properties : list[str] | None
+        Properties to search over. Defaults to ["text"].
+
+    Returns
+    -------
+    list[dict[str, Any]]
+        Results with same structure as vector_search for compatibility.
+    """
+    if query_properties is None:
+        query_properties = DEFAULT_QUERY_PROPERTIES
+
+    client = get_weaviate_client()
+    collection = client.collections.get(CHUNK_COLLECTION)
+
+    response = collection.query.bm25(
+        query=query,
+        limit=top_k,
+        query_properties=query_properties,
+        return_metadata=["score"],
+    )
+
+    results: list[dict[str, Any]] = []
+    for obj in response.objects:
+        props = obj.properties
+        score = (
+            getattr(obj.metadata, "score", None)
+            if hasattr(obj, "metadata")
+            else None
+        )
+
+        results.append(
+            {
+                "chunk_id": props.get("chunk_id"),
+                "document_id": props.get("document_id"),
+                "page_number": props.get("page_number"),
+                "section_title": props.get("section_title"),
+                "text": props.get("text"),
+                "source_file": props.get("source_file"),
+                "similarity_score": round(float(score), 4) if score is not None else None,
+            }
+        )
+
+    return results

--- a/src/retrieval/retriever.py
+++ b/src/retrieval/retriever.py
@@ -1,60 +1,32 @@
-"""Retriever orchestration: query embedding + vector search + optional reranking."""
+"""Retriever orchestration: query embedding + search strategy dispatch + optional reranking."""
 
 import logging
 from pathlib import Path
 
 from .models import RetrievalResult
-from .query_embedding import embed_query
-from .vector_search import vector_search
 
 logger = logging.getLogger(__name__)
 
+VALID_STRATEGIES = ("vector", "keyword", "hybrid")
 
-def _load_reranking_config() -> dict:
-    """Load reranking config from config.yaml. Returns empty dict on failure."""
+
+def _load_config() -> dict:
+    """Load full config from config.yaml. Returns empty dict on failure."""
     try:
         import yaml
 
         config_path = Path(__file__).resolve().parent.parent.parent / "config" / "config.yaml"
         if config_path.exists():
             with open(config_path) as f:
-                cfg = yaml.safe_load(f)
-            return cfg.get("reranking", {})
+                return yaml.safe_load(f) or {}
     except Exception:
         pass
     return {}
 
 
-def retrieve(
-    query: str,
-    top_k: int = 5,
-    min_similarity: float = 0.0,
-) -> list[RetrievalResult]:
-    """
-    Retrieve top-K most relevant chunks for a query.
-
-    Pipeline: query → embed → vector_search → [optional rerank] → results.
-
-    When reranking is enabled via config, over-retrieves (top_k * 2) from
-    vector search then reranks down to top_k.
-
-    Returns
-    -------
-    list[RetrievalResult]
-        Ranked retrieval results ordered by similarity/relevance score.
-    """
-    rerank_cfg = _load_reranking_config()
-    reranking_enabled = rerank_cfg.get("enabled", False)
-
-    # Over-retrieve when reranking to give cross-encoder more candidates
-    fetch_k = top_k * 2 if reranking_enabled else top_k
-
-    query_vector = embed_query(query)
-    raw_results = vector_search(
-        query_vector, top_k=fetch_k, min_similarity=min_similarity,
-    )
-
-    results = [
+def _raw_to_results(raw_results: list[dict]) -> list[RetrievalResult]:
+    """Convert raw search dicts to RetrievalResult dataclass instances."""
+    return [
         RetrievalResult(
             text=r.get("text") or "",
             chunk_id=r.get("chunk_id") or "",
@@ -67,6 +39,97 @@ def retrieve(
         for r in raw_results
     ]
 
+
+def retrieve(
+    query: str,
+    top_k: int = 5,
+    min_similarity: float = 0.0,
+    search_strategy: str | None = None,
+    alpha: float | None = None,
+) -> list[RetrievalResult]:
+    """
+    Retrieve top-K most relevant chunks for a query.
+
+    Supports three search strategies:
+    - "vector": semantic search via BGE-M3 embeddings (default)
+    - "keyword": BM25 keyword search
+    - "hybrid": combined BM25 + vector search
+
+    When reranking is enabled via config, over-retrieves (top_k * 2) then
+    reranks down to top_n.
+
+    Parameters
+    ----------
+    query : str
+        The user query.
+    top_k : int
+        Number of results to return.
+    min_similarity : float
+        Minimum similarity threshold (applied only for "vector" strategy).
+    search_strategy : str | None
+        Override search strategy. If None, reads from config.yaml
+        (retrieval.search_strategy). Defaults to "vector" if not configured.
+    alpha : float | None
+        Override hybrid alpha. If None, reads from config.yaml
+        (retrieval.hybrid.alpha). Defaults to 0.5.
+
+    Returns
+    -------
+    list[RetrievalResult]
+        Ranked retrieval results ordered by similarity/relevance score.
+    """
+    cfg = _load_config()
+    retrieval_cfg = cfg.get("retrieval", {})
+    rerank_cfg = cfg.get("reranking", {})
+    reranking_enabled = rerank_cfg.get("enabled", False)
+
+    # Resolve search strategy
+    strategy = search_strategy or retrieval_cfg.get("search_strategy", "vector")
+    if strategy not in VALID_STRATEGIES:
+        raise ValueError(
+            f"Invalid search_strategy: {strategy!r}. "
+            f"Must be one of: {VALID_STRATEGIES}"
+        )
+
+    # Over-retrieve when reranking to give cross-encoder more candidates
+    fetch_k = top_k * 2 if reranking_enabled else top_k
+
+    # Dispatch to appropriate search function
+    if strategy == "keyword":
+        from .keyword_search import keyword_search
+
+        raw_results = keyword_search(query, top_k=fetch_k)
+        results = _raw_to_results(raw_results)
+
+    elif strategy == "hybrid":
+        from .hybrid_search import hybrid_search
+        from .query_embedding import embed_query
+
+        hybrid_cfg = retrieval_cfg.get("hybrid", {})
+        resolved_alpha = alpha if alpha is not None else hybrid_cfg.get("alpha", 0.5)
+        fusion_type = hybrid_cfg.get("fusion_type", "ranked")
+
+        query_vector = embed_query(query)
+        raw_results = hybrid_search(
+            query=query,
+            query_vector=query_vector,
+            top_k=fetch_k,
+            alpha=resolved_alpha,
+            fusion_type=fusion_type,
+        )
+        results = _raw_to_results(raw_results)
+
+    else:  # "vector" (default)
+        from .query_embedding import embed_query
+        from .vector_search import vector_search
+
+        query_vector = embed_query(query)
+        raw_results = vector_search(
+            query_vector, top_k=fetch_k, min_similarity=min_similarity,
+        )
+        results = _raw_to_results(raw_results)
+
+    # Apply reranking if enabled
     if reranking_enabled and results:
         from .reranker import rerank
 

--- a/src/retrieval/vector_search.py
+++ b/src/retrieval/vector_search.py
@@ -2,8 +2,7 @@
 
 from typing import Any
 
-from src.embeddings.validation import BGE_M3_DIMENSIONS
-from src.vectorstore.weaviate_client import CHUNK_COLLECTION, get_weaviate_client
+from src.vectorstore.weaviate_client import BGE_M3_DIMENSIONS, CHUNK_COLLECTION, get_weaviate_client
 
 
 def vector_search(

--- a/tests/test_hybrid_search.py
+++ b/tests/test_hybrid_search.py
@@ -1,0 +1,107 @@
+"""Unit tests for hybrid search (BM25 + vector)."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+import src.retrieval.hybrid_search as hs_module
+
+
+def _make_hybrid_obj(chunk_id: str, score: float | None) -> MagicMock:
+    """Create a mock Weaviate hybrid response object."""
+    obj = MagicMock()
+    obj.properties = {
+        "chunk_id": chunk_id,
+        "document_id": "doc",
+        "page_number": 1,
+        "section_title": "Section 1",
+        "text": f"text for {chunk_id}",
+        "source_file": "test.pdf",
+    }
+    obj.metadata.score = score
+    return obj
+
+
+def _mock_hybrid_search(objects: list[MagicMock], **kwargs):
+    """Run hybrid_search with mocked Weaviate client."""
+    mock_response = MagicMock()
+    mock_response.objects = objects
+
+    mock_collection = MagicMock()
+    mock_collection.query.hybrid.return_value = mock_response
+
+    mock_client = MagicMock()
+    mock_client.collections.get.return_value = mock_collection
+
+    dummy_vector = [0.0] * 1024
+
+    with patch.object(hs_module, "get_weaviate_client", return_value=mock_client):
+        if "query_vector" not in kwargs:
+            kwargs["query_vector"] = dummy_vector
+        results = hs_module.hybrid_search(**kwargs)
+        return results, mock_collection
+
+
+def test_hybrid_search_returns_results() -> None:
+    """Hybrid search returns results with correct structure."""
+    objects = [
+        _make_hybrid_obj("c1", score=0.85),
+        _make_hybrid_obj("c2", score=0.62),
+    ]
+    results, _ = _mock_hybrid_search(objects, query="chave Pix")
+    assert len(results) == 2
+    assert results[0]["chunk_id"] == "c1"
+    assert results[0]["similarity_score"] == 0.85
+    assert results[0]["text"] == "text for c1"
+    assert results[0]["document_id"] == "doc"
+
+
+def test_hybrid_search_passes_alpha_and_vector() -> None:
+    """Alpha and vector are forwarded to Weaviate hybrid query."""
+    objects = [_make_hybrid_obj("c1", score=0.8)]
+    dummy_vector = [0.0] * 1024
+    _, mock_collection = _mock_hybrid_search(
+        objects, query="test", query_vector=dummy_vector, alpha=0.7,
+    )
+    call_kwargs = mock_collection.query.hybrid.call_args.kwargs
+    assert call_kwargs["alpha"] == 0.7
+    assert call_kwargs["vector"] == dummy_vector
+
+
+def test_hybrid_search_default_fusion_type() -> None:
+    """Default fusion type is 'ranked' (RRF)."""
+    from weaviate.classes.query import HybridFusion
+
+    objects = [_make_hybrid_obj("c1", score=0.8)]
+    _, mock_collection = _mock_hybrid_search(objects, query="test")
+    call_kwargs = mock_collection.query.hybrid.call_args.kwargs
+    assert call_kwargs["fusion_type"] == HybridFusion.RANKED
+
+
+def test_hybrid_search_relative_score_fusion() -> None:
+    """Relative score fusion type is correctly applied."""
+    from weaviate.classes.query import HybridFusion
+
+    objects = [_make_hybrid_obj("c1", score=0.8)]
+    _, mock_collection = _mock_hybrid_search(
+        objects, query="test", fusion_type="relative_score",
+    )
+    call_kwargs = mock_collection.query.hybrid.call_args.kwargs
+    assert call_kwargs["fusion_type"] == HybridFusion.RELATIVE_SCORE
+
+
+def test_hybrid_search_validates_vector_dimensions() -> None:
+    """Invalid embedding dimensions raise ValueError."""
+    with pytest.raises(ValueError, match="Invalid embedding dimension"):
+        _mock_hybrid_search([], query="test", query_vector=[0.0] * 512)
+
+
+def test_hybrid_search_validates_alpha_range() -> None:
+    """Alpha outside [0, 1] raises ValueError."""
+    with pytest.raises(ValueError, match="alpha must be between"):
+        _mock_hybrid_search([], query="test", query_vector=[0.0] * 1024, alpha=1.5)
+
+
+def test_hybrid_search_empty_results() -> None:
+    """Empty response returns empty list."""
+    results, _ = _mock_hybrid_search([], query="nonexistent")
+    assert results == []

--- a/tests/test_keyword_search.py
+++ b/tests/test_keyword_search.py
@@ -1,0 +1,86 @@
+"""Unit tests for BM25 keyword search."""
+
+from unittest.mock import MagicMock, patch
+
+import src.retrieval.keyword_search as ks_module
+
+
+def _make_bm25_obj(chunk_id: str, score: float | None) -> MagicMock:
+    """Create a mock Weaviate BM25 response object."""
+    obj = MagicMock()
+    obj.properties = {
+        "chunk_id": chunk_id,
+        "document_id": "doc",
+        "page_number": 1,
+        "section_title": "Section 1",
+        "text": f"text for {chunk_id}",
+        "source_file": "test.pdf",
+    }
+    obj.metadata.score = score
+    return obj
+
+
+def _mock_keyword_search(objects: list[MagicMock], **kwargs):
+    """Run keyword_search with mocked Weaviate client."""
+    mock_response = MagicMock()
+    mock_response.objects = objects
+
+    mock_collection = MagicMock()
+    mock_collection.query.bm25.return_value = mock_response
+
+    mock_client = MagicMock()
+    mock_client.collections.get.return_value = mock_collection
+
+    with patch.object(ks_module, "get_weaviate_client", return_value=mock_client):
+        results = ks_module.keyword_search(**kwargs)
+        return results, mock_collection
+
+
+def test_keyword_search_returns_results() -> None:
+    """BM25 search returns results with correct structure."""
+    objects = [
+        _make_bm25_obj("c1", score=5.2),
+        _make_bm25_obj("c2", score=3.1),
+    ]
+    results, _ = _mock_keyword_search(objects, query="Art. 3", top_k=5)
+    assert len(results) == 2
+    assert results[0]["chunk_id"] == "c1"
+    assert results[0]["similarity_score"] == 5.2
+    assert results[0]["text"] == "text for c1"
+    assert results[0]["document_id"] == "doc"
+    assert results[0]["page_number"] == 1
+    assert results[0]["source_file"] == "test.pdf"
+
+
+def test_keyword_search_respects_top_k() -> None:
+    """Limit parameter is passed to Weaviate BM25 query."""
+    objects = [_make_bm25_obj("c1", score=5.0)]
+    _, mock_collection = _mock_keyword_search(objects, query="test", top_k=3)
+    mock_collection.query.bm25.assert_called_once()
+    call_kwargs = mock_collection.query.bm25.call_args
+    assert call_kwargs.kwargs["limit"] == 3
+
+
+def test_keyword_search_default_properties() -> None:
+    """Default query_properties is ['text']."""
+    objects = [_make_bm25_obj("c1", score=5.0)]
+    _, mock_collection = _mock_keyword_search(objects, query="test")
+    call_kwargs = mock_collection.query.bm25.call_args
+    assert call_kwargs.kwargs["query_properties"] == ["text"]
+
+
+def test_keyword_search_custom_properties() -> None:
+    """Custom query_properties are forwarded to Weaviate."""
+    objects = [_make_bm25_obj("c1", score=5.0)]
+    custom_props = ["text", "section_title"]
+    _, mock_collection = _mock_keyword_search(
+        objects, query="test", query_properties=custom_props,
+    )
+    call_kwargs = mock_collection.query.bm25.call_args
+    assert call_kwargs.kwargs["query_properties"] == custom_props
+
+
+def test_keyword_search_empty_results() -> None:
+    """Empty response returns empty list."""
+    results, _ = _mock_keyword_search([], query="nonexistent")
+    assert results == []

--- a/tests/test_retriever_strategy.py
+++ b/tests/test_retriever_strategy.py
@@ -1,0 +1,166 @@
+"""Unit tests for retriever search strategy dispatch.
+
+Uses patch.object on directly-imported modules to avoid triggering
+the sentence_transformers → tf_keras import chain on Windows.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from src.retrieval.models import RetrievalResult
+
+# These modules DON'T trigger sentence_transformers import chain
+import src.retrieval.retriever as retriever_module
+import src.retrieval.keyword_search as ks_module
+import src.retrieval.hybrid_search as hs_module
+import src.retrieval.vector_search as vs_module
+
+
+def _make_raw_result(chunk_id: str = "c1", score: float = 0.8) -> dict:
+    return {
+        "chunk_id": chunk_id,
+        "document_id": "doc",
+        "page_number": 1,
+        "section_title": None,
+        "text": f"text for {chunk_id}",
+        "source_file": "test.pdf",
+        "similarity_score": score,
+    }
+
+
+VECTOR_CONFIG = {
+    "retrieval": {"search_strategy": "vector", "min_similarity": 0.0},
+    "reranking": {"enabled": False},
+}
+
+KEYWORD_CONFIG = {
+    "retrieval": {"search_strategy": "keyword"},
+    "reranking": {"enabled": False},
+}
+
+HYBRID_CONFIG = {
+    "retrieval": {
+        "search_strategy": "hybrid",
+        "hybrid": {"alpha": 0.6, "fusion_type": "ranked"},
+    },
+    "reranking": {"enabled": False},
+}
+
+
+def _mock_embed_query(return_value=None):
+    """Create a mock for embed_query that patches at the right level."""
+    if return_value is None:
+        return_value = [0.0] * 1024
+    # Since retrieve() does `from .query_embedding import embed_query`,
+    # we need to patch the name in the query_embedding module.
+    # But query_embedding.py imports sentence_transformers at module level,
+    # which fails on Windows. Instead, we mock the entire lazy import
+    # by injecting the mock into the retriever's local scope.
+    return patch.object(
+        retriever_module,
+        "_embed_query_fn",
+        return_value=return_value,
+        create=True,
+    )
+
+
+def test_retrieve_vector_strategy_calls_vector_search() -> None:
+    """Vector strategy calls embed_query + vector_search."""
+    mock_embed = MagicMock(return_value=[0.0] * 1024)
+    with (
+        patch.object(retriever_module, "_load_config", return_value=VECTOR_CONFIG),
+        patch.object(vs_module, "vector_search", return_value=[_make_raw_result()]) as mock_vs,
+        patch.dict("sys.modules", {"src.retrieval.query_embedding": MagicMock(embed_query=mock_embed)}),
+    ):
+        results = retriever_module.retrieve("test query", top_k=5, search_strategy="vector")
+        mock_embed.assert_called_once_with("test query")
+        mock_vs.assert_called_once()
+        assert len(results) == 1
+        assert isinstance(results[0], RetrievalResult)
+
+
+def test_retrieve_keyword_strategy_calls_keyword_search() -> None:
+    """Keyword strategy calls keyword_search, no embedding generated."""
+    with (
+        patch.object(retriever_module, "_load_config", return_value=KEYWORD_CONFIG),
+        patch.object(ks_module, "keyword_search", return_value=[_make_raw_result()]) as mock_ks,
+    ):
+        results = retriever_module.retrieve("Art. 3", top_k=5, search_strategy="keyword")
+        mock_ks.assert_called_once()
+        assert len(results) == 1
+
+
+def test_retrieve_hybrid_strategy_calls_hybrid_search() -> None:
+    """Hybrid strategy calls embed_query + hybrid_search."""
+    mock_embed = MagicMock(return_value=[0.0] * 1024)
+    with (
+        patch.object(retriever_module, "_load_config", return_value=HYBRID_CONFIG),
+        patch.object(hs_module, "hybrid_search", return_value=[_make_raw_result()]) as mock_hs,
+        patch.dict("sys.modules", {"src.retrieval.query_embedding": MagicMock(embed_query=mock_embed)}),
+    ):
+        results = retriever_module.retrieve("chave Pix", top_k=5, search_strategy="hybrid")
+        mock_embed.assert_called_once_with("chave Pix")
+        mock_hs.assert_called_once()
+        call_kwargs = mock_hs.call_args.kwargs
+        assert call_kwargs["alpha"] == 0.6
+        assert call_kwargs["fusion_type"] == "ranked"
+        assert len(results) == 1
+
+
+def test_retrieve_default_strategy_is_vector() -> None:
+    """When no strategy is configured, defaults to vector search."""
+    empty_config = {"retrieval": {}, "reranking": {"enabled": False}}
+    mock_embed = MagicMock(return_value=[0.0] * 1024)
+    with (
+        patch.object(retriever_module, "_load_config", return_value=empty_config),
+        patch.object(vs_module, "vector_search", return_value=[_make_raw_result()]) as mock_vs,
+        patch.dict("sys.modules", {"src.retrieval.query_embedding": MagicMock(embed_query=mock_embed)}),
+    ):
+        results = retriever_module.retrieve("test", top_k=5)
+        mock_vs.assert_called_once()
+        assert len(results) == 1
+
+
+def test_retrieve_parameter_overrides_config() -> None:
+    """Explicit search_strategy param overrides config.yaml value."""
+    mock_embed = MagicMock(return_value=[0.0] * 1024)
+    with (
+        patch.object(retriever_module, "_load_config", return_value=HYBRID_CONFIG),
+        patch.object(vs_module, "vector_search", return_value=[_make_raw_result()]) as mock_vs,
+        patch.dict("sys.modules", {"src.retrieval.query_embedding": MagicMock(embed_query=mock_embed)}),
+    ):
+        # Config says "hybrid" but param says "vector"
+        retriever_module.retrieve("test", top_k=5, search_strategy="vector")
+        mock_vs.assert_called_once()
+
+
+def test_retrieve_min_similarity_skipped_for_keyword() -> None:
+    """min_similarity is not applied for keyword strategy (BM25 scores differ)."""
+    with (
+        patch.object(retriever_module, "_load_config", return_value=KEYWORD_CONFIG),
+        patch.object(ks_module, "keyword_search", return_value=[_make_raw_result()]),
+    ):
+        # min_similarity=0.9 would filter out score=0.8 for vector, but keyword ignores it
+        results = retriever_module.retrieve("test", top_k=5, search_strategy="keyword", min_similarity=0.9)
+        assert len(results) == 1
+
+
+def test_retrieve_alpha_parameter_overrides_config() -> None:
+    """Alpha parameter overrides config hybrid.alpha value."""
+    mock_embed = MagicMock(return_value=[0.0] * 1024)
+    with (
+        patch.object(retriever_module, "_load_config", return_value=HYBRID_CONFIG),
+        patch.object(hs_module, "hybrid_search", return_value=[_make_raw_result()]) as mock_hs,
+        patch.dict("sys.modules", {"src.retrieval.query_embedding": MagicMock(embed_query=mock_embed)}),
+    ):
+        retriever_module.retrieve("test", top_k=5, search_strategy="hybrid", alpha=0.3)
+        call_kwargs = mock_hs.call_args.kwargs
+        assert call_kwargs["alpha"] == 0.3  # param, not config's 0.6
+
+
+def test_retrieve_invalid_strategy_raises() -> None:
+    """Invalid search strategy raises ValueError."""
+    empty_config = {"retrieval": {}, "reranking": {"enabled": False}}
+    with patch.object(retriever_module, "_load_config", return_value=empty_config):
+        with pytest.raises(ValueError, match="Invalid search_strategy"):
+            retriever_module.retrieve("test", top_k=5, search_strategy="invalid")


### PR DESCRIPTION
Milestone: Hybrid Search

- Implement BM25 (keyword-based) retrieval
- Add hybrid search (BM25 + vector) using native Weaviate support
- Introduce configurable retrieval strategy dispatch
- Add comparison script with alpha sweep for hybrid weighting

Enables evaluation of lexical vs semantic vs hybrid retrieval approaches.

Refs: Milestone 3 — Hybrid Search