### PR TITLE
fix(retrieval): chunk deduplication, reranking span visibility, and response spacing

### DIFF
--- a/app/components/results.py
+++ b/app/components/results.py
@@ -10,6 +10,19 @@ def _esc(s: str) -> str:
     return html.escape(str(s)) if s else ""
 
 
+def _format_answer(raw: str) -> str:
+    """Convert plain-text answer to HTML paragraphs with controlled spacing."""
+    if not raw:
+        return ""
+    paragraphs = raw.strip().split("\n\n")
+    formatted = []
+    for p in paragraphs:
+        escaped = html.escape(p.strip())
+        escaped = escaped.replace("\n", "<br>")
+        formatted.append(f"<p>{escaped}</p>")
+    return "".join(formatted)
+
+
 def render_metrics_row(bl: dict[str, Any], rag: dict[str, Any]) -> None:
     """Render the top-level metrics cards."""
     st.markdown(
@@ -43,8 +56,8 @@ def render_metrics_row(bl: dict[str, Any], rag: dict[str, Any]) -> None:
 
 def render_comparison(bl: dict[str, Any], rag: dict[str, Any]) -> None:
     """Render side-by-side Baseline vs RAG comparison cards."""
-    bl_ans = _esc(bl["answer"])
-    rag_ans = _esc(rag["answer"])
+    bl_ans = _format_answer(bl["answer"])
+    rag_ans = _format_answer(rag["answer"])
 
     col_bl, col_vs, col_rag = st.columns([10, 1, 10])
 

--- a/app/styles.py
+++ b/app/styles.py
@@ -178,10 +178,12 @@ CSS = """
   /* ── Response text ── */
   .response-text {
     font-size: 0.91rem;
-    line-height: 1.8;
+    line-height: 1.7;
     color: #1e293b;
     min-height: 120px;
-    white-space: pre-wrap;
+  }
+  .response-text p {
+    margin: 0.4em 0;
   }
 
   /* ── Meta row ── */

--- a/src/retrieval/retriever.py
+++ b/src/retrieval/retriever.py
@@ -70,6 +70,22 @@ def _raw_to_results(raw_results: list[dict]) -> list[RetrievalResult]:
     ]
 
 
+def _deduplicate(results: list[RetrievalResult]) -> list[RetrievalResult]:
+    """Remove duplicate chunks by chunk_id, keeping the highest-scored entry."""
+    seen: dict[str, RetrievalResult] = {}
+    for r in results:
+        key = r.chunk_id or str(id(r))
+        existing = seen.get(key)
+        if existing is None:
+            seen[key] = r
+        elif (r.similarity_score or 0.0) > (existing.similarity_score or 0.0):
+            seen[key] = r
+    deduped = list(seen.values())
+    if len(deduped) < len(results):
+        logger.info("Deduplicated %d → %d chunks", len(results), len(deduped))
+    return deduped
+
+
 def retrieve(
     query: str,
     top_k: int = 5,
@@ -245,6 +261,9 @@ def retrieve(
                 _set_result_attributes(span, results)
                 span_set_output(span, {"count": len(results), "latency_ms": elapsed_ms})
 
+    # Deduplicate before reranking to avoid wasting cross-encoder inference
+    results = _deduplicate(results)
+
     # Apply reranking if enabled
     if reranking_enabled and results:
         from .reranker import rerank
@@ -259,7 +278,7 @@ def retrieve(
                 "reranking.input_count": len(results),
                 "reranking.top_n": top_n,
             },
-            openinference_span_kind="reranker",
+            openinference_span_kind="retriever",
         ) as span:
             t0 = time.perf_counter()
             logger.info(
@@ -281,9 +300,17 @@ def retrieve(
                         span.set_attribute("reranking.top_score", round(max(scores), 4))
                         span.set_attribute("reranking.min_score", round(min(scores), 4))
                 _set_result_attributes(span, results)
+                output_docs = [
+                    {
+                        "rank": i + 1,
+                        "chunk_id": r.chunk_id,
+                        "score": round(r.similarity_score, 4) if r.similarity_score else None,
+                    }
+                    for i, r in enumerate(results)
+                ]
                 span_set_output(
                     span,
-                    {"count": len(results), "latency_ms": elapsed_ms},
+                    {"count": len(results), "latency_ms": elapsed_ms, "reranked_documents": output_docs},
                 )
 
     return results


### PR DESCRIPTION
## Summary

- Add `_deduplicate()` in `retriever.py` to remove duplicate chunks by `chunk_id` before reranking, keeping the highest-scored entry
- Fix reranking span kind from invalid `"reranker"` to `"retriever"` (recognized by OpenInference spec), making Phoenix render span attributes and output correctly
- Enrich reranking span output with structured document list (rank, chunk_id, score)
- Remove `white-space: pre-wrap` from `.response-text` CSS and add `_format_answer()` helper that converts `\n\n` to `<p>` tags with controlled margin

## Changes

| File | Description |
|------|-------------|
| `src/retrieval/retriever.py` | `_deduplicate()` helper + call before reranking; span kind fix + structured output |
| `app/styles.py` | Remove `pre-wrap`, add `.response-text p` margin rule |
| `app/components/results.py` | `_format_answer()` replaces raw `_esc()` for answer rendering |

## Test plan

- [ ] `pytest -m "not slow and not integration"` — 212 tests pass, no regressions
- [ ] Re-index after collection reset → no duplicate chunks in Phoenix trace
- [ ] Reranking span in Phoenix shows attributes and output tab with reranked documents
- [ ] Streamlit response cards show compact paragraph spacing without blank lines
