### PR TITLE
feat: incremental indexing with content-hash change detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,8 @@ jobs:
         run: |
           pip install pydantic pydantic-settings pymupdf pytest pytest-cov \
                       transformers weaviate-client numpy pyyaml \
-                      python-json-logger ollama
+                      python-json-logger ollama requests \
+                      sentence-transformers opentelemetry-api
 
       - name: Run unit tests with coverage
         run: |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # RAG Pix Regulation
 
+[![CI](https://github.com/brunoramosmartins/rag-pix-regulation/actions/workflows/ci.yml/badge.svg)](https://github.com/brunoramosmartins/rag-pix-regulation/actions/workflows/ci.yml)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+[![Weaviate](https://img.shields.io/badge/Vector%20DB-Weaviate-orange.svg)](https://weaviate.io/)
+[![OpenTelemetry](https://img.shields.io/badge/Observability-OpenTelemetry%20%2B%20Phoenix-purple.svg)](https://docs.arize.com/phoenix)
+
 A **Retrieval-Augmented Generation (RAG)** system for querying Brazilian Pix regulatory documentation. Built for fraud prevention teams, compliance analysts, and AI agents that require accurate, traceable answers grounded in official Central Bank (BCB) regulations and the DICT Operational Manual (MED 2.0).
 
 ---
@@ -44,16 +50,59 @@ The project is successful when:
 
 | Phase | Description | Status |
 |-------|-------------|--------|
-| **1. Setup** | Repo, venv, dependencies | ✅ Complete |
-| **2. Ingestion** | PDF parsing, text extraction, metadata | ✅ Complete |
-| **3. Chunking** | Structural + token-based chunking | ✅ Complete |
-| **4. Embeddings** | BGE-M3 vectors, Weaviate indexing | ✅ Complete |
-| **5. Retrieval** | Semantic search, Recall@K, Precision@K | ✅ Complete |
-| **6. RAG Pipeline** | Prompt template, answer generation, citations | ✅ Complete |
-| **7. Evaluation & Observability** | Metrics, Phoenix tracing, evaluation runner | ✅ Complete |
-| **8. Demo & Publication** | Streamlit app, documentation | 🔄 In Progress |
+| **1. Setup** | Repo, venv, dependencies | Done |
+| **2. Ingestion** | PDF parsing, text extraction, metadata | Done |
+| **3. Chunking** | Structural + token-based chunking | Done |
+| **4. Embeddings** | BGE-M3 vectors, Weaviate indexing | Done |
+| **5. Retrieval** | Semantic search, Recall@K, Precision@K | Done |
+| **6. RAG Pipeline** | Prompt template, answer generation, citations | Done |
+| **7. Evaluation & Observability** | Metrics, Phoenix tracing, evaluation runner | Done |
+| **8. Incremental Indexing** | Content hashing, change detection, ingestion tracing | Done |
+| **9. Demo & Publication** | Streamlit app, documentation | In Progress |
 
-> **Note:** The full pipeline (phases 1–7) is functional. The Streamlit demo (`app/`) is under active development.
+---
+
+## Recent: Incremental Indexing & Ingestion Observability (v1.1.0)
+
+Inspired by [Two years of vector search at Notion](https://www.notion.com/pt/blog/two-years-of-vector-search-at-notion), the indexing pipeline was upgraded from full-reindex to **incremental indexing** with content-hash change detection. This addresses the article's core insight: **the dominant cost in RAG systems is not search, but maintaining and updating embeddings.**
+
+### What changed
+
+| Before | After |
+|--------|-------|
+| Every run re-embeds all chunks | Only new/changed chunks are embedded |
+| No change detection | SHA-256 content hash per chunk |
+| No embedding provenance | `embedding_model` stored per vector |
+| Ingestion pipeline untraced | Full OpenTelemetry tracing on ingestion |
+
+### How it works
+
+```
+Chunks loaded from JSONL
+        |
+Fetch existing hashes from Weaviate
+        |
+Classify: new / changed / unchanged
+        |
+Skip unchanged --- only embed new + changed
+        |
+Insert with content_hash + embedding_model metadata
+        |
+Log: "Indexed 12 new, 3 updated, 85 skipped"
+```
+
+### Impact assessment (Notion article practices)
+
+| Practice | Status | Notes |
+|----------|--------|-------|
+| Content hash change detection | Implemented | SHA-256 per chunk |
+| Incremental indexing | Implemented | Skip unchanged, update changed |
+| Embedding versioning metadata | Implemented | `embedding_model` stored per vector |
+| Ingestion pipeline tracing | Implemented | Full spans in Phoenix |
+| Decoupled ingestion/serving | Already done | Stateless serving reads from Weaviate |
+| Self-hosted embeddings | Already done | BGE-M3 via sentence-transformers |
+| Batch processing | Already done | batch_size=32 embeddings |
+| Sharding / real-time ingestion | Skipped | Not relevant at current scale |
 
 ---
 
@@ -61,23 +110,24 @@ The project is successful when:
 
 ```
 Regulatory PDFs
-       ↓
+       |
    Parsing
-       ↓
-   Chunking
-       ↓
+       |
+   Chunking (+ SHA-256 content hash)
+       |
   Embeddings
-       ↓
+       |
 Vector Database (Weaviate)
-       ↓
+  [content_hash + embedding_model metadata]
+       |
    Retriever
-       ↓
+       |
   Prompt Builder
-       ↓
+       |
       LLM
-       ↓
+       |
 Grounded Answer + Source Citations
-       ↓
+       |
 Evaluation + Observability (Phoenix)
 ```
 
@@ -106,10 +156,11 @@ rag-pix-regulation/
 │   ├── ingestion/        # Document loading and PDF parsing
 │   ├── chunking/         # Document splitting strategies
 │   ├── embeddings/       # Vector representations
-│   ├── vectorstore/      # Weaviate client and indexing
+│   ├── vectorstore/      # Weaviate client, schema, incremental indexing
 │   ├── retrieval/        # Similarity search
 │   ├── rag/              # RAG pipeline orchestration
 │   ├── evaluation/       # Retrieval quality, grounding, hallucination metrics
+│   ├── config/           # Pydantic Settings, structured logging
 │   └── observability/    # Phoenix tracing and monitoring
 ├── scripts/              # Utility and pipeline scripts
 ├── notebooks/            # Experimentation and analysis
@@ -124,9 +175,11 @@ rag-pix-regulation/
 | **ingestion** | Load and parse documents from various sources |
 | **chunking** | Split documents into retrieval-optimized chunks |
 | **embeddings** | Generate vector representations for semantic search |
+| **vectorstore** | Weaviate client, schema management, incremental indexing |
 | **retrieval** | Similarity search and ranking |
 | **rag** | Orchestrate retrieval + generation pipeline |
 | **evaluation** | Measure retrieval quality and grounding |
+| **config** | Centralized Pydantic Settings with YAML + env var support |
 | **observability** | Phoenix integration for tracing and debugging |
 
 ---
@@ -180,38 +233,48 @@ docker compose up -d
 Then run the full pipeline (or use the single script below):
 
 ```bash
-python scripts/run_ingestion.py   # PDF → corpus_pages.jsonl
-python scripts/run_chunking.py   # pages → corpus_chunks.jsonl
+python scripts/run_ingestion.py   # PDF -> corpus_pages.jsonl
+python scripts/run_chunking.py   # pages -> corpus_chunks.jsonl
 python scripts/init_weaviate.py  # Create collection schema
-python scripts/run_indexing.py   # Chunks → embeddings → Weaviate
+python scripts/run_indexing.py   # Chunks -> embeddings -> Weaviate
 python scripts/demo_retrieval.py # Demo semantic search
 ```
 
 **Single-command pipeline:**
 
 ```bash
-python scripts/run_pipeline.py   # Runs ingestion → chunking → init_weaviate → indexing
+python scripts/run_pipeline.py   # Runs ingestion -> chunking -> init_weaviate -> indexing
+```
+
+**Incremental re-indexing:** After the first run, subsequent runs only process new or changed chunks:
+
+```bash
+python scripts/run_indexing.py   # Skips unchanged chunks automatically
+# Output: "Indexed 0 new, 0 updated, 120 skipped"
 ```
 
 ### Data Pipeline
 
 ```
 PDF (data/raw/)
-       ↓
+       |
 Parsing + Cleaning + Metadata
-       ↓
+       |
 corpus_pages.jsonl
-       ↓
+       |
 Structural segmentation
-       ↓
-Token chunking
-       ↓
+       |
+Token chunking (+ SHA-256 content hash)
+       |
 corpus_chunks.jsonl
-       ↓
+       |
+Incremental indexing (skip unchanged)
+       |
 Embeddings (BGE-M3)
-       ↓
+       |
 Vector indexing (Weaviate)
-       ↓
+  [content_hash + embedding_model metadata]
+       |
 Semantic retrieval
 ```
 
@@ -227,10 +290,11 @@ The chunk dataset (`corpus_chunks.jsonl`) uses one JSON object per line:
 | `segment_index` | int | Segment index within page |
 | `chunk_index` | int | Chunk index within segment |
 | `section_title` | string | Section title (e.g. "1 Chaves Pix") |
-| `article_numbers` | list | Article markers (e.g. ["Art. 1º", "§2º"]) |
+| `article_numbers` | list | Article markers (e.g. ["Art. 1o", "par.2o"]) |
 | `source_file` | string | Source PDF filename |
 | `text` | string | Chunk text content |
 | `token_count` | int | Number of tokens |
+| `content_hash` | string | SHA-256 hash of text for change detection |
 
 ### Demo (Interactive Interface)
 
@@ -244,10 +308,10 @@ streamlit run app/streamlit_app.py
 
 **Example queries:**
 - Como funciona o registro de chave Pix?
-- Quais são as regras de devolução por fraude?
+- Quais sao as regras de devolucao por fraude?
 - Como funciona a portabilidade de chave Pix?
 - Quantas chaves Pix posso ter por conta?
-- O que é o DICT no contexto do Pix?
+- O que e o DICT no contexto do Pix?
 
 The demo shows side-by-side responses, citations, and retrieved context chunks.
 
@@ -302,7 +366,8 @@ Key parameters:
 | **5. Retrieval** | Validated retriever | Semantic search, Recall@K, Precision@K |
 | **6. RAG Pipeline** | End-to-end question answering | Prompt template, RAG pipeline, baseline comparison |
 | **7. Evaluation & Observability** | Measurable, observable system | Metrics, Phoenix tracing, logs |
-| **8. Demo & Publication** | Portfolio-ready project | Streamlit app, documentation, video, LinkedIn |
+| **8. Incremental Indexing** | Production-grade indexing pipeline | Content hashing, change detection, ingestion tracing |
+| **9. Demo & Publication** | Portfolio-ready project | Streamlit app, documentation, video, LinkedIn |
 
 ---
 

--- a/config/document_aliases.yaml
+++ b/config/document_aliases.yaml
@@ -1,17 +1,24 @@
 # Document display aliases
-# Maps document_id (filename stem, lowercase) → human-readable name shown in citations and UI.
+# Maps document_id (filename stem, lowercase) -> human-readable name shown in citations and UI.
 # document_id is generated from the PDF filename: stem.lower().replace(" ", "_")
 
-# ── Current names (post-rename) ───────────────────────────────────────────────
+# Current corpus (numbered PDFs)
+01_manual_uso_marca_pix: "Manual de Uso da Marca Pix v1.6"
+02_manual_padroes_iniciacao_pix: "Manual de Padroes para Iniciacao do Pix v2.9.0"
+03_manual_fluxos_efetivacao_pix: "Manual de Fluxos de Efetivacao do Pix v2.1"
+04_requisitos_minimos_experiencia_usuario: "Requisitos Minimos para Experiencia do Usuario"
+05_manual_tempos_pix: "Manual de Tempos do Pix v7.0"
+06_manual_operacional_dict: "Manual Operacional do DICT (MED 2.0)"
+07_manual_resolucao_disputas: "Manual de Resolucao de Disputas v5.0"
+
+# Legacy names (pre-rename) -- kept for backward compatibility with old indexes
+x_manualoperacionaldodict: "Manual Operacional do DICT (MED 2.0)"
 manual_operacional_dict: "Manual Operacional do DICT (MED 2.0)"
 manual_tempos_pix: "Manual de Tempos do Pix v7.0"
-manual_interfaces_comunicacao: "Manual das Interfaces de Comunicação v1.12"
-manual_resolucao_disputas: "Manual de Resolução de Disputas v5.0"
+manual_interfaces_comunicacao: "Manual das Interfaces de Comunicacao v1.12"
+manual_resolucao_disputas: "Manual de Resolucao de Disputas v5.0"
 manual_fluxos_pix: "Manual de Fluxos do Pix v2.1"
-manual_iniciacao_pix: "Manual de Padrões para Iniciação do Pix v2.9.0"
+manual_iniciacao_pix: "Manual de Padroes para Iniciacao do Pix v2.9.0"
 manual_marca_pix: "Manual de Uso da Marca Pix v1.6"
-
-# ── Legacy names (pre-rename) — remove after full re-index ───────────────────
-x_manualoperacionaldodict: "Manual Operacional do DICT (MED 2.0)"
 ix_manualdtempsdopix: "Manual de Tempos do Pix v7.0"
-xi_manual_de_resolucao_de_disputa: "Manual de Resolução de Disputas v5.0"
+xi_manual_de_resolucao_de_disputa: "Manual de Resolucao de Disputas v5.0"

--- a/data/SOURCES.md
+++ b/data/SOURCES.md
@@ -2,15 +2,15 @@
 
 Source documents indexed in the RAG knowledge base. All are official publications of the Banco Central do Brasil (BCB).
 
-| Alias | Filename | Version | Source URL |
-|-------|----------|---------|------------|
-| Manual Operacional do DICT (MED 2.0) | `manual_operacional_dict.pdf` | MED 2.0 | [bcb.gov.br](https://www.bcb.gov.br/content/estabilidadefinanceira/pix/Regulamento_Pix/X_ManualOperacionaldoDICT.pdf) |
-| Manual de Tempos do Pix v7.0 | `manual_tempos_pix.pdf` | v7.0 | [bcb.gov.br](https://www.bcb.gov.br/content/estabilidadefinanceira/pix/Regulamento_Pix/IX_ManualdeTemposdoPix.pdf) |
-| Manual das Interfaces de Comunicação v1.12 | `manual_interfaces_comunicacao.pdf` | v1.12 | [bcb.gov.br](https://www.bcb.gov.br/content/estabilidadefinanceira/pix/Regulamento_Pix/Manual_das_Interfaces_de_Comunicacao.pdf) |
-| Manual de Resolução de Disputas v5.0 | `manual_resolucao_disputas.pdf` | v5.0 | [bcb.gov.br](https://www.bcb.gov.br/content/estabilidadefinanceira/pix/Regulamento_Pix/XI_Manual_de_resolucao_de_disputa.pdf) |
-| Manual de Fluxos do Pix v2.1 | `manual_fluxos_pix.pdf` | v2.1 | [bcb.gov.br](https://www.bcb.gov.br/content/estabilidadefinanceira/pix/Regulamento_Pix/Manual_Fluxos_Efetivacao_Pix.pdf) |
-| Manual de Padrões para Iniciação do Pix v2.9.0 | `manual_iniciacao_pix.pdf` | v2.9.0 | [bcb.gov.br](https://www.bcb.gov.br/content/estabilidadefinanceira/pix/Regulamento_Pix/Manual_Padroes_Iniciacao_Pix.pdf) |
-| Manual de Uso da Marca Pix v1.6 | `manual_marca_pix.pdf` | v1.6 | [bcb.gov.br](https://www.bcb.gov.br/content/estabilidadefinanceira/pix/marca_pix/Manual_de_Uso_da_Marca_Pix.pdf) |
+| Alias | Filename | document_id | Source URL |
+|-------|----------|-------------|------------|
+| Manual de Uso da Marca Pix v1.6 | `01_manual_uso_marca_pix.pdf` | `01_manual_uso_marca_pix` | [bcb.gov.br](https://www.bcb.gov.br/content/estabilidadefinanceira/pix/marca_pix/Manual_de_Uso_da_Marca_Pix.pdf) |
+| Manual de Padroes para Iniciacao do Pix v2.9.0 | `02_manual_padroes_iniciacao_pix.pdf` | `02_manual_padroes_iniciacao_pix` | [bcb.gov.br](https://www.bcb.gov.br/content/estabilidadefinanceira/pix/Regulamento_Pix/Manual_Padroes_Iniciacao_Pix.pdf) |
+| Manual de Fluxos de Efetivacao do Pix v2.1 | `03_manual_fluxos_efetivacao_pix.pdf` | `03_manual_fluxos_efetivacao_pix` | [bcb.gov.br](https://www.bcb.gov.br/content/estabilidadefinanceira/pix/Regulamento_Pix/Manual_Fluxos_Efetivacao_Pix.pdf) |
+| Requisitos Minimos para Experiencia do Usuario | `04_requisitos_minimos_experiencia_usuario.pdf` | `04_requisitos_minimos_experiencia_usuario` | [bcb.gov.br](https://www.bcb.gov.br/content/estabilidadefinanceira/pix/Regulamento_Pix/Requisitos_minimos_experiencia_usuario.pdf) |
+| Manual de Tempos do Pix v7.0 | `05_manual_tempos_pix.pdf` | `05_manual_tempos_pix` | [bcb.gov.br](https://www.bcb.gov.br/content/estabilidadefinanceira/pix/Regulamento_Pix/IX_ManualdeTemposdoPix.pdf) |
+| Manual Operacional do DICT (MED 2.0) | `06_manual_operacional_dict.pdf` | `06_manual_operacional_dict` | [bcb.gov.br](https://www.bcb.gov.br/content/estabilidadefinanceira/pix/Regulamento_Pix/X_ManualOperacionaldoDICT.pdf) |
+| Manual de Resolucao de Disputas v5.0 | `07_manual_resolucao_disputas.pdf` | `07_manual_resolucao_disputas` | [bcb.gov.br](https://www.bcb.gov.br/content/estabilidadefinanceira/pix/Regulamento_Pix/XI_Manual_de_resolucao_de_disputa.pdf) |
 
 ---
 
@@ -27,7 +27,7 @@ Source documents indexed in the RAG knowledge base. All are official publication
 After adding new PDFs to `data/raw/`, rebuild the full pipeline:
 
 ```bash
-make pipeline   # or: python scripts/run_pipeline.py
+python scripts/run_pipeline.py
 ```
 
-This clears and rebuilds the Weaviate collection with all documents.
+For subsequent runs, the incremental indexer will skip unchanged chunks automatically.

--- a/data/evaluation/rag_evaluation_dataset.json
+++ b/data/evaluation/rag_evaluation_dataset.json
@@ -1,6 +1,6 @@
 {
   "description": "Canonical evaluation dataset — Manual Operacional do DICT. Single source for retrieval and RAG evaluation.",
-  "source_corpus": "manual_dict",
+  "source_corpus": "06_manual_operacional_dict",
   "difficulty_tiers": {
     "single_chunk": "Answer found in a single chunk",
     "multi_chunk": "Answer requires combining information from 2+ chunks",
@@ -13,7 +13,7 @@
       "query": "O que é o processo de Recuperação de Valores no Pix e qual é seu objetivo?",
       "difficulty": "single_chunk",
       "expected_pages": [122],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "A Recuperação de Valores é um aprimoramento do MED para rastrear, bloquear e devolver recursos em transações Pix suspeitas de fraude ou golpe.",
       "key_concepts": [
         "rastreamento de transações",
@@ -30,7 +30,7 @@
       "query": "Quais são as principais etapas do processo de Recuperação de Valores no DICT?",
       "difficulty": "multi_chunk",
       "expected_pages": [123, 124],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "O processo inclui as etapas: instauração, rastreamento, priorização, bloqueio, análise e devolução.",
       "key_concepts": [
         "fluxo estruturado",
@@ -46,7 +46,7 @@
       "query": "Quais são os possíveis estados de uma Recuperação de Valores no DICT?",
       "difficulty": "single_chunk",
       "expected_pages": [122],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "Uma Recuperação de Valores pode ter os seguintes estados: CREATED, TRACKED, AWAITING_ANALYSIS, ANALYSED, REFUNDING, COMPLETED, CANCELLED.",
       "key_concepts": [
         "estados do processo",
@@ -61,7 +61,7 @@
       "query": "Quem pode abrir uma notificação de infração para solicitação de devolução?",
       "difficulty": "single_chunk",
       "expected_pages": [69],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "A notificação de infração para solicitação de devolução pode ser aberta apenas pelo PSP do pagador quando há suspeita de fraude em uma transação Pix.",
       "key_concepts": [
         "PSP do pagador",
@@ -77,7 +77,7 @@
       "query": "Quais são os estados possíveis de uma notificação de infração no DICT?",
       "difficulty": "single_chunk",
       "expected_pages": [69],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "Uma notificação de infração pode estar nos estados: aberta, recebida, analisada/concluída/fechada, cancelada.",
       "key_concepts": [
         "fluxo de tratamento de infração",
@@ -92,7 +92,7 @@
       "query": "Em que situações pode ser criada uma marcação de fraude transacional no DICT?",
       "difficulty": "single_chunk",
       "expected_pages": [84],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "A marcação de fraude pode ser criada quando um PSP identifica envolvimento em fraude, como conta-laranja, conta de fraudador, acesso fraudulento ou outros.",
       "key_concepts": [
         "fraude transacional",
@@ -108,7 +108,7 @@
       "query": "Quais informações devem ser fornecidas ao criar uma marcação de fraude transacional no DICT?",
       "difficulty": "single_chunk",
       "expected_pages": [84],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "Devem ser informados: CPF ou CNPJ do usuário suspeito, chave Pix (quando conhecida), tipo de fraude e informações adicionais sobre o caso.",
       "key_concepts": [
         "identificação do usuário",
@@ -124,7 +124,7 @@
       "query": "Qual é o prazo para que o PSP do pagador inicie uma solicitação de devolução após a conclusão da notificação de infração?",
       "difficulty": "single_chunk",
       "expected_pages": [105],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "O PSP do pagador tem até 72 horas após a conclusão da notificação de infração para iniciar a solicitação de devolução.",
       "key_concepts": [
         "prazo de 72 horas",
@@ -140,7 +140,7 @@
       "query": "O valor solicitado para devolução em um processo de fraude pode ser maior que o valor da transação original?",
       "difficulty": "single_chunk",
       "expected_pages": [106, 130],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "Não. O valor solicitado para devolução deve ser igual ou menor que o valor da transação original.",
       "key_concepts": [
         "limite de devolução",
@@ -156,7 +156,7 @@
       "query": "O que acontece quando uma solicitação de devolução é concluída no DICT?",
       "difficulty": "multi_chunk",
       "expected_pages": [106, 107],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "A solicitação é marcada como concluída no DICT com um dos seguintes resultados: aceita total, aceita parcial ou rejeitada. O PSP do pagador consulta periodicamente essas solicitações concluídas.",
       "key_concepts": [
         "estados finais da devolução",
@@ -172,7 +172,7 @@
       "query": "Quais são os tipos de chaves Pix aceitos no DICT e seus formatos?",
       "difficulty": "single_chunk",
       "expected_pages": [5],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "Os tipos de chave são: telefone celular (formato E.164), e-mail, CPF (11 dígitos), CNPJ (14 dígitos) e chave aleatória (EVP, UUID v4).",
       "key_concepts": [
         "tipos de chave Pix",
@@ -190,7 +190,7 @@
       "query": "Como o participante do Pix deve validar o número de telefone celular ou e-mail antes do registro da chave?",
       "difficulty": "single_chunk",
       "expected_pages": [6],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "O participante deve enviar um código para o telefone ou e-mail e solicitar a inclusão desse código em algum canal de atendimento, validando a posse do dado.",
       "key_concepts": [
         "validação de posse",
@@ -206,7 +206,7 @@
       "query": "Quais verificações de conformidade o DICT realiza ao receber uma solicitação de registro de chave Pix?",
       "difficulty": "single_chunk",
       "expected_pages": [10],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "O DICT verifica: i) se o PSP com acesso direto possui autorização para registrar chaves, e ii) se o PSP vinculado à chave é o mesmo do usuário final.",
       "key_concepts": [
         "verificação de conformidade",
@@ -222,7 +222,7 @@
       "query": "Como funciona o fluxo de registro de chave para participantes com acesso indireto ao DICT?",
       "difficulty": "multi_chunk",
       "expected_pages": [11, 12],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "O PSP com acesso indireto solicita o registro ao PSP com acesso direto (liquidante no SPI), que encaminha a requisição ao DICT. A resposta segue o caminho inverso.",
       "key_concepts": [
         "acesso indireto",
@@ -238,7 +238,7 @@
       "query": "Quais verificações o DICT faz ao receber uma solicitação de exclusão de chave?",
       "difficulty": "single_chunk",
       "expected_pages": [20],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "O DICT verifica: i) a chave está registrada, ii) o PSP que solicitou é o mesmo que efetuou o registro, e iii) a chave pertence ao usuário que solicitou a exclusão.",
       "key_concepts": [
         "exclusão de chave",
@@ -254,7 +254,7 @@
       "query": "Como funciona o fluxo de exclusão de chave para participantes com acesso indireto ao DICT?",
       "difficulty": "single_chunk",
       "expected_pages": [21],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "O PSP do usuário final inicia o processo de exclusão enviando a mensagem 'Diretório / Remover Vínculo' ao DICT através do PSP com acesso direto.",
       "key_concepts": [
         "exclusão via acesso indireto",
@@ -269,7 +269,7 @@
       "query": "O que é o processo de portabilidade de chave Pix e como ele é iniciado?",
       "difficulty": "single_chunk",
       "expected_pages": [24],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "A portabilidade permite transferir uma chave de um PSP para outro. O PSP reivindicador inicia o pedido, que fica com status 'Aberto' no DICT aguardando resposta do PSP doador.",
       "key_concepts": [
         "portabilidade de chave",
@@ -286,7 +286,7 @@
       "query": "Qual o prazo que o usuário tem para confirmar ou cancelar uma portabilidade de chave Pix?",
       "difficulty": "single_chunk",
       "expected_pages": [30],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "O usuário tem até sete dias para confirmar ou cancelar a portabilidade. Para cancelar, deve fazer validação ativa da chave.",
       "key_concepts": [
         "prazo de 7 dias",
@@ -302,7 +302,7 @@
       "query": "O que acontece quando o status da portabilidade é 'Confirmado' no DICT?",
       "difficulty": "single_chunk",
       "expected_pages": [35],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "Quando confirmado, o DICT bloqueia a chave até o recebimento da confirmação pelo PSP reivindicador. O bloqueio impede consultas a essa chave.",
       "key_concepts": [
         "bloqueio de chave",
@@ -318,7 +318,7 @@
       "query": "O que é o fluxo de reivindicação de posse de chave Pix?",
       "difficulty": "single_chunk",
       "expected_pages": [40],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "A reivindicação de posse ocorre quando um usuário deseja registrar uma chave que já pertence a outro usuário. O PSP doador consulta periodicamente reivindicações com status 'Aberto' no DICT.",
       "key_concepts": [
         "reivindicação de posse",
@@ -334,7 +334,7 @@
       "query": "Como funciona o fluxo de consulta de chave Pix pelo usuário pagador?",
       "difficulty": "multi_chunk",
       "expected_pages": [55, 56],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "O usuário pagador insere a chave (manualmente ou via QR Code), o PSP verifica na base interna e, se não encontrar, consulta o DICT através do PSP com acesso direto.",
       "key_concepts": [
         "consulta de chave",
@@ -351,7 +351,7 @@
       "query": "O que é o processo de verificação de sincronismo no DICT e quais são seus conceitos fundamentais?",
       "difficulty": "single_chunk",
       "expected_pages": [61],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "A verificação de sincronismo usa dois conceitos: CID (identificador de conteúdo, 256 bits gerado a partir de dados da chave) e VSync (verificador de sincronismo).",
       "key_concepts": [
         "sincronismo",
@@ -368,7 +368,7 @@
       "query": "Como funciona o fluxo de reconciliação de chaves por arquivo no DICT?",
       "difficulty": "single_chunk",
       "expected_pages": [66],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "O PSP com acesso direto solicita a lista de suas chaves por tipo específico através da mensagem 'Reconciliação / Criar Arquivo' ao DICT.",
       "key_concepts": [
         "reconciliação",
@@ -384,7 +384,7 @@
       "query": "Quais são os tipos de fraude reconhecidos na notificação de infração do DICT?",
       "difficulty": "single_chunk",
       "expected_pages": [71],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "Os tipos incluem: fraudulent_access (acesso e autorização fraudulenta por terceiro via engenharia social) e outros tipos de fraude transacional.",
       "key_concepts": [
         "fraudulent_access",
@@ -400,7 +400,7 @@
       "query": "Quais são os tipos de conta fraudadora reconhecidos na marcação de fraude do DICT?",
       "difficulty": "single_chunk",
       "expected_pages": [84],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "Os tipos incluem: mule_account (conta-laranja aberta legitimamente para receber fraude), scammer_account (conta no nome do próprio fraudador) e other (outros).",
       "key_concepts": [
         "mule_account",
@@ -416,7 +416,7 @@
       "query": "O que é a funcionalidade checkKeys do DICT e quem pode usá-la?",
       "difficulty": "single_chunk",
       "expected_pages": [90],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "checkKeys é uma funcionalidade do DICT de uso exclusivo do PSP para confirmar a existência de chaves antes de enviar requisições. Não pode ser disponibilizada aos usuários.",
       "key_concepts": [
         "checkKeys",
@@ -432,7 +432,7 @@
       "query": "Como funciona a política de limitação de requisições à API do DICT?",
       "difficulty": "multi_chunk",
       "expected_pages": [91, 92],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "Cada operação da API tem uma política de limitação com um 'balde' (margem para exceder o limite temporariamente). Diferentes operações têm limites específicos, como 70 requisições/min para checkKeys.",
       "key_concepts": [
         "rate limiting",
@@ -449,7 +449,7 @@
       "query": "O que é o cache de existência de chave Pix e qual sua finalidade?",
       "difficulty": "single_chunk",
       "expected_pages": [95],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "O cache de existência permite ao PSP com acesso indireto armazenar localmente informações sobre existência de chaves, atualizado via lista do DICT.",
       "key_concepts": [
         "cache local",
@@ -465,7 +465,7 @@
       "query": "Qual o prazo máximo para o PSP do pagador solicitar devolução por falha operacional?",
       "difficulty": "single_chunk",
       "expected_pages": [100],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "A solicitação de devolução por falha operacional pode ser feita se a transação ocorreu nos últimos noventa dias.",
       "key_concepts": [
         "devolução por falha operacional",
@@ -481,7 +481,7 @@
       "query": "Como o PSP do recebedor deve agir ao receber uma solicitação de devolução por falha operacional?",
       "difficulty": "multi_chunk",
       "expected_pages": [100, 101],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "O PSP do recebedor verifica se existem recursos disponíveis na conta. Caso existam, prossegue com a devolução. Caso não se trate de falha operacional ou não existam recursos, segue para rejeição.",
       "key_concepts": [
         "verificação de recursos",
@@ -497,7 +497,7 @@
       "query": "É possível cancelar uma devolução já aceita pelo PSP do pagador?",
       "difficulty": "single_chunk",
       "expected_pages": [110],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "Sim, o PSP do pagador deve iniciar uma nova transação (pacs.008) para cancelar, pois não é possível devolver a devolução original via pacs.004.",
       "key_concepts": [
         "cancelamento de devolução",
@@ -513,7 +513,7 @@
       "query": "O que são as notificações de eventos no DICT e qual sua finalidade?",
       "difficulty": "single_chunk",
       "expected_pages": [140],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "O endpoint de eventos é uma forma centralizada de consultar eventos no DICT que necessitem de ação de um PSP. Inicialmente, somente eventos da Recuperação de Valores são consultados.",
       "key_concepts": [
         "endpoint de eventos",
@@ -529,7 +529,7 @@
       "query": "Quais eventos existem relacionados à Recuperação de Valores no sistema de notificações?",
       "difficulty": "single_chunk",
       "expected_pages": [141],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "Existe o evento FUNDS_RECOVERY_ANALYSED, que significa que a Recuperação de Valores teve seu status atualizado para ANALYSED.",
       "key_concepts": [
         "FUNDS_RECOVERY_ANALYSED",
@@ -545,7 +545,7 @@
       "query": "O que acontece com a chave durante o processo de reivindicação de posse quando o status é 'Confirmado'?",
       "difficulty": "cross_section",
       "expected_pages": [35, 36],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "Quando confirmado, o DICT bloqueia a chave e atualiza os dados vinculados, alterando o status da solicitação. O bloqueio impede consultas até a conclusão.",
       "key_concepts": [
         "bloqueio de chave",
@@ -562,7 +562,7 @@
       "query": "Quais regras se aplicam ao nome vinculado a uma chave Pix do tipo CPF ou CNPJ?",
       "difficulty": "multi_chunk",
       "expected_pages": [7, 8],
-      "expected_documents": ["manual_dict"],
+      "expected_documents": ["06_manual_operacional_dict"],
       "expected_answer_summary": "O nome não pode conter palavras inexistentes no registro da Receita Federal. Cada palavra deve ser grafada de forma idêntica, com exceções para diacríticos, hífens e caracteres especiais.",
       "key_concepts": [
         "nome vinculado à chave",

--- a/data/evaluation/rag_queries.json
+++ b/data/evaluation/rag_queries.json
@@ -3,27 +3,27 @@
     {
       "query_id": "rq1",
       "query": "Como funciona o cadastro de chave Pix?",
-      "expected_documents": ["manual_dict"]
+      "expected_documents": ["06_manual_operacional_dict"]
     },
     {
       "query_id": "rq2",
       "query": "Regras para devolução por fraude",
-      "expected_documents": ["manual_dict"]
+      "expected_documents": ["06_manual_operacional_dict"]
     },
     {
       "query_id": "rq3",
       "query": "Processo de portabilidade de chave Pix",
-      "expected_documents": ["manual_dict"]
+      "expected_documents": ["06_manual_operacional_dict"]
     },
     {
       "query_id": "rq4",
       "query": "Quais são os limites de transação do Pix?",
-      "expected_documents": ["manual_dict"]
+      "expected_documents": ["06_manual_operacional_dict"]
     },
     {
       "query_id": "rq5",
       "query": "Como solicitar estorno de transação Pix?",
-      "expected_documents": ["manual_dict"]
+      "expected_documents": ["06_manual_operacional_dict"]
     }
   ]
 }

--- a/data/raw/.gitkeep
+++ b/data/raw/.gitkeep
@@ -1,1 +1,0 @@
-# Raw data files (PDFs, documents before processing)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rag-pix-regulation"
-version = "0.7.0"
+version = "1.1.0"
 description = "RAG system for querying Brazilian Pix regulatory documentation"
 requires-python = ">=3.10"
 authors = [{ name = "Bruno Ramos Martins" }]

--- a/src/chunking/models.py
+++ b/src/chunking/models.py
@@ -1,6 +1,13 @@
 """Data models for chunking stage."""
 
+import hashlib
+
 from pydantic import BaseModel, Field
+
+
+def compute_content_hash(text: str) -> str:
+    """Compute SHA-256 hash of text content for change detection."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
 class Chunk(BaseModel):
@@ -21,6 +28,10 @@ class Chunk(BaseModel):
     source_file: str = Field(..., description="Source PDF filename.")
     text: str = Field(..., description="Chunk text content.")
     token_count: int = Field(..., ge=0, description="Number of tokens in chunk.")
+    content_hash: str = Field(
+        default="",
+        description="SHA-256 hash of text content for incremental indexing.",
+    )
     char_start: int | None = Field(
         default=None, description="Start offset in segment text."
     )

--- a/src/chunking/token_chunker.py
+++ b/src/chunking/token_chunker.py
@@ -4,7 +4,7 @@ from typing import Iterable
 
 from transformers import AutoTokenizer
 
-from .models import Chunk, StructuralSegment
+from .models import Chunk, StructuralSegment, compute_content_hash
 
 DEFAULT_MODEL = "BAAI/bge-m3"
 DEFAULT_CHUNK_SIZE = 500
@@ -88,6 +88,7 @@ def chunk_segment(
                 source_file=segment.source_file,
                 text=chunk_text,
                 token_count=token_count,
+                content_hash=compute_content_hash(chunk_text),
                 char_start=segment.char_start,
                 char_end=segment.char_end,
             )
@@ -122,6 +123,7 @@ def chunk_segment(
                 source_file=segment.source_file,
                 text=chunk_text,
                 token_count=token_window_count,
+                content_hash=compute_content_hash(chunk_text),
                 char_start=None,
                 char_end=None,
             )

--- a/src/vectorstore/indexer.py
+++ b/src/vectorstore/indexer.py
@@ -1,13 +1,23 @@
-"""Chunk indexing pipeline for Weaviate vector database."""
+"""Chunk indexing pipeline for Weaviate vector database.
+
+Supports incremental indexing: only new or changed chunks are embedded and indexed.
+Uses content hashing (SHA-256) to detect changes.
+"""
 
 import logging
+import time
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from weaviate.classes.data import DataObject
+from weaviate.classes.query import Filter
 
 from src.chunking.loader import load_chunks_jsonl
+from src.chunking.models import Chunk
+from src.config import get_settings
 from src.embeddings.embedding_generator import generate_embeddings
 from src.embeddings.validation import BGE_M3_DIMENSIONS, validate_chunk_embedding_pairs
+from src.observability.tracing import trace_span
 
 from .weaviate_client import (
     CHUNK_COLLECTION,
@@ -22,6 +32,86 @@ DEFAULT_BATCH_SIZE = 100
 EMBEDDING_BATCH_SIZE = 32
 
 
+@dataclass
+class IndexingStats:
+    """Statistics from an indexing run."""
+
+    total: int = 0
+    new: int = 0
+    updated: int = 0
+    skipped: int = 0
+    deleted: int = 0
+    embedding_time_ms: float = 0
+    insert_time_ms: float = 0
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def indexed(self) -> int:
+        return self.new + self.updated
+
+
+def _fetch_existing_hashes(collection, chunk_ids: list[str]) -> dict[str, str]:
+    """Fetch content_hash for existing chunks in Weaviate by chunk_id.
+
+    Returns a dict of {chunk_id: content_hash}.
+    """
+    existing: dict[str, str] = {}
+    for cid in chunk_ids:
+        try:
+            result = collection.query.fetch_objects(
+                filters=Filter.by_property("chunk_id").equal(cid),
+                limit=1,
+                return_properties=["chunk_id", "content_hash"],
+            )
+            if result.objects:
+                obj = result.objects[0]
+                existing[cid] = obj.properties.get("content_hash", "")
+        except Exception as e:
+            logger.debug("Failed to query chunk %s: %s", cid, e)
+    return existing
+
+
+def _delete_chunks_by_ids(collection, chunk_ids: list[str]) -> int:
+    """Delete chunks from Weaviate by chunk_id. Returns count deleted."""
+    deleted = 0
+    for cid in chunk_ids:
+        try:
+            result = collection.query.fetch_objects(
+                filters=Filter.by_property("chunk_id").equal(cid),
+                limit=1,
+            )
+            if result.objects:
+                collection.data.delete_by_id(result.objects[0].uuid)
+                deleted += 1
+        except Exception as e:
+            logger.debug("Failed to delete chunk %s: %s", cid, e)
+    return deleted
+
+
+def _classify_chunks(
+    chunks: list[Chunk],
+    existing_hashes: dict[str, str],
+) -> tuple[list[Chunk], list[Chunk], list[Chunk]]:
+    """Classify chunks into new, changed, and unchanged.
+
+    Returns (new_chunks, changed_chunks, unchanged_chunks).
+    """
+    new_chunks: list[Chunk] = []
+    changed_chunks: list[Chunk] = []
+    unchanged_chunks: list[Chunk] = []
+
+    for chunk in chunks:
+        old_hash = existing_hashes.get(chunk.chunk_id)
+        if old_hash is None:
+            new_chunks.append(chunk)
+        elif old_hash != chunk.content_hash:
+            changed_chunks.append(chunk)
+        else:
+            unchanged_chunks.append(chunk)
+
+    return new_chunks, changed_chunks, unchanged_chunks
+
+
 def index_chunks(
     chunks_path: Path,
     batch_size: int = DEFAULT_BATCH_SIZE,
@@ -30,44 +120,157 @@ def index_chunks(
     """
     Load chunks, generate embeddings, and index into Weaviate.
 
-    Returns the number of chunks indexed.
+    When recreate_collection is False, performs incremental indexing:
+    only new or changed chunks (by content_hash) are embedded and inserted.
+
+    Returns the number of chunks indexed (new + updated).
     """
-    client = get_weaviate_client()
-    init_chunk_collection(client, recreate=recreate_collection)
-    collection = client.collections.get(CHUNK_COLLECTION)
+    settings = get_settings()
+    embedding_model = settings.embeddings.model
 
-    chunks = list(load_chunks_jsonl(chunks_path))
-    if not chunks:
-        logger.warning("No chunks to index")
-        return 0
+    with trace_span(
+        "indexing_pipeline",
+        attributes={"indexing.recreate_collection": recreate_collection},
+        openinference_span_kind="CHAIN",
+    ) as pipeline_span:
+        client = get_weaviate_client()
+        init_chunk_collection(client, recreate=recreate_collection)
+        collection = client.collections.get(CHUNK_COLLECTION)
 
-    total_chunks = len(chunks)
-    total_indexed = 0
-    batch: list[tuple] = []
+        chunks = list(load_chunks_jsonl(chunks_path))
+        if not chunks:
+            logger.warning("No chunks to index")
+            return 0
 
-    for i in range(0, len(chunks), EMBEDDING_BATCH_SIZE):
-        chunk_batch = chunks[i : i + EMBEDDING_BATCH_SIZE]
-        pairs = generate_embeddings(chunk_batch, batch_size=EMBEDDING_BATCH_SIZE)
-        validate_chunk_embedding_pairs(pairs, expected_dim=BGE_M3_DIMENSIONS)
+        stats = IndexingStats(total=len(chunks))
 
-        for chunk, embedding in pairs:
-            props = chunk_to_weaviate_properties(chunk)
-            batch.append(
-                DataObject(
-                    properties=props,
-                    vector=embedding,
-                )
+        if pipeline_span and pipeline_span.is_recording():
+            pipeline_span.set_attribute("indexing.chunks_total", stats.total)
+            pipeline_span.set_attribute("indexing.embedding_model", embedding_model)
+
+        # --- Incremental classification ---
+        if recreate_collection:
+            new_chunks = chunks
+            changed_chunks: list[Chunk] = []
+        else:
+            with trace_span(
+                "fetch_existing_hashes",
+                attributes={"chunks_to_check": len(chunks)},
+            ):
+                chunk_ids = [c.chunk_id for c in chunks]
+                existing_hashes = _fetch_existing_hashes(collection, chunk_ids)
+
+            new_chunks, changed_chunks, unchanged_chunks = _classify_chunks(
+                chunks, existing_hashes
+            )
+            stats.skipped = len(unchanged_chunks)
+
+            logger.info(
+                "Incremental analysis: %d new, %d changed, %d unchanged (skipped)",
+                len(new_chunks),
+                len(changed_chunks),
+                stats.skipped,
             )
 
-        if len(batch) >= batch_size:
-            collection.data.insert_many(batch)
+        # Delete changed chunks before re-inserting with new embeddings
+        if changed_chunks:
+            with trace_span(
+                "delete_changed_chunks",
+                attributes={"chunks_to_delete": len(changed_chunks)},
+            ):
+                stats.deleted = _delete_chunks_by_ids(
+                    collection, [c.chunk_id for c in changed_chunks]
+                )
+
+        # Chunks that need embedding: new + changed
+        chunks_to_embed = new_chunks + changed_chunks
+        if not chunks_to_embed:
+            logger.info(
+                "All %d chunks unchanged — nothing to index", stats.total
+            )
+            if pipeline_span and pipeline_span.is_recording():
+                pipeline_span.set_attribute("indexing.chunks_skipped", stats.skipped)
+                pipeline_span.set_attribute("indexing.chunks_indexed", 0)
+            return 0
+
+        # --- Embed and insert ---
+        total_indexed = 0
+        batch: list[DataObject] = []
+
+        for i in range(0, len(chunks_to_embed), EMBEDDING_BATCH_SIZE):
+            chunk_batch = chunks_to_embed[i : i + EMBEDDING_BATCH_SIZE]
+
+            t0 = time.perf_counter()
+            with trace_span(
+                "batch_embedding",
+                attributes={
+                    "batch_index": i // EMBEDDING_BATCH_SIZE,
+                    "batch_size": len(chunk_batch),
+                },
+            ):
+                pairs = generate_embeddings(
+                    chunk_batch, batch_size=EMBEDDING_BATCH_SIZE
+                )
+                validate_chunk_embedding_pairs(pairs, expected_dim=BGE_M3_DIMENSIONS)
+            stats.embedding_time_ms += (time.perf_counter() - t0) * 1000
+
+            for chunk, embedding in pairs:
+                props = chunk_to_weaviate_properties(
+                    chunk, embedding_model=embedding_model
+                )
+                batch.append(DataObject(properties=props, vector=embedding))
+
+            if len(batch) >= batch_size:
+                t1 = time.perf_counter()
+                with trace_span(
+                    "weaviate_insert",
+                    attributes={"batch_size": len(batch)},
+                ):
+                    collection.data.insert_many(batch)
+                stats.insert_time_ms += (time.perf_counter() - t1) * 1000
+                total_indexed += len(batch)
+                logger.info(
+                    "Indexed %d / %d chunks", total_indexed, len(chunks_to_embed)
+                )
+                batch = []
+
+        if batch:
+            t1 = time.perf_counter()
+            with trace_span(
+                "weaviate_insert",
+                attributes={"batch_size": len(batch)},
+            ):
+                collection.data.insert_many(batch)
+            stats.insert_time_ms += (time.perf_counter() - t1) * 1000
             total_indexed += len(batch)
-            logger.info("Indexed %d / %d chunks", total_indexed, total_chunks)
-            batch = []
+            logger.info(
+                "Indexed %d / %d chunks", total_indexed, len(chunks_to_embed)
+            )
 
-    if batch:
-        collection.data.insert_many(batch)
-        total_indexed += len(batch)
-        logger.info("Indexed %d / %d chunks", total_indexed, total_chunks)
+        # Classify new vs updated counts
+        stats.new = min(len(new_chunks), total_indexed)
+        stats.updated = total_indexed - stats.new
 
-    return total_indexed
+        logger.info(
+            "Indexing complete: %d new, %d updated, %d skipped "
+            "(embedding: %.0fms, insert: %.0fms)",
+            stats.new,
+            stats.updated,
+            stats.skipped,
+            stats.embedding_time_ms,
+            stats.insert_time_ms,
+        )
+
+        if pipeline_span and pipeline_span.is_recording():
+            pipeline_span.set_attribute("indexing.chunks_new", stats.new)
+            pipeline_span.set_attribute("indexing.chunks_updated", stats.updated)
+            pipeline_span.set_attribute("indexing.chunks_skipped", stats.skipped)
+            pipeline_span.set_attribute("indexing.chunks_indexed", total_indexed)
+            pipeline_span.set_attribute(
+                "indexing.embedding_time_ms", stats.embedding_time_ms
+            )
+            pipeline_span.set_attribute(
+                "indexing.insert_time_ms", stats.insert_time_ms
+            )
+
+        return total_indexed

--- a/src/vectorstore/weaviate_client.py
+++ b/src/vectorstore/weaviate_client.py
@@ -85,6 +85,8 @@ def init_chunk_collection(
                 Property(name="article_numbers", data_type=DataType.TEXT_ARRAY),
                 Property(name="source_file", data_type=DataType.TEXT),
                 Property(name="text", data_type=DataType.TEXT),
+                Property(name="content_hash", data_type=DataType.TEXT),
+                Property(name="embedding_model", data_type=DataType.TEXT),
             ],
         )
         logger.info(
@@ -113,7 +115,9 @@ def validate_chunk_schema(client: weaviate.WeaviateClient | None = None) -> bool
     return True
 
 
-def chunk_to_weaviate_properties(chunk: Any) -> dict[str, Any]:
+def chunk_to_weaviate_properties(
+    chunk: Any, embedding_model: str = ""
+) -> dict[str, Any]:
     """Convert Chunk to Weaviate properties dict."""
     return {
         "chunk_id": chunk.chunk_id,
@@ -125,4 +129,6 @@ def chunk_to_weaviate_properties(chunk: Any) -> dict[str, Any]:
         "article_numbers": chunk.article_numbers or [],
         "source_file": chunk.source_file,
         "text": chunk.text,
+        "content_hash": getattr(chunk, "content_hash", ""),
+        "embedding_model": embedding_model,
     }

--- a/tests/test_content_hash.py
+++ b/tests/test_content_hash.py
@@ -1,0 +1,292 @@
+"""Tests for content hashing and incremental indexing classification."""
+
+import hashlib
+
+from src.chunking.models import Chunk, StructuralSegment, compute_content_hash
+from src.chunking.token_chunker import chunk_segment
+
+
+# ── compute_content_hash ────────────────────────────────────────────────────
+
+
+def test_hash_deterministic() -> None:
+    """Same text always produces the same hash."""
+    text = "Art. 1º O arranjo de pagamentos Pix"
+    assert compute_content_hash(text) == compute_content_hash(text)
+
+
+def test_hash_differs_for_different_text() -> None:
+    """Different text produces different hashes."""
+    h1 = compute_content_hash("Text A")
+    h2 = compute_content_hash("Text B")
+    assert h1 != h2
+
+
+def test_hash_is_sha256_hex() -> None:
+    """Hash should be a 64-char hex string (SHA-256)."""
+    h = compute_content_hash("test")
+    assert len(h) == 64
+    assert all(c in "0123456789abcdef" for c in h)
+
+
+def test_hash_matches_stdlib() -> None:
+    """Verify hash matches direct hashlib computation."""
+    text = "Regulamentação PIX"
+    expected = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    assert compute_content_hash(text) == expected
+
+
+def test_hash_unicode_handling() -> None:
+    """Unicode text (accents, special chars) is hashed correctly."""
+    text = "§ 2º — não será permitido"
+    h = compute_content_hash(text)
+    assert len(h) == 64
+
+
+# ── Chunk model with content_hash ───────────────────────────────────────────
+
+
+def test_chunk_model_includes_content_hash() -> None:
+    """Chunk model has content_hash field."""
+    chunk = Chunk(
+        chunk_id="doc_p1_s0_c0",
+        document_id="doc",
+        page_number=1,
+        segment_index=0,
+        chunk_index=0,
+        source_file="doc.pdf",
+        text="Test text",
+        token_count=2,
+        content_hash=compute_content_hash("Test text"),
+    )
+    assert chunk.content_hash == compute_content_hash("Test text")
+
+
+def test_chunk_model_default_hash_is_empty() -> None:
+    """Backward compatibility: content_hash defaults to empty string."""
+    chunk = Chunk(
+        chunk_id="doc_p1_s0_c0",
+        document_id="doc",
+        page_number=1,
+        segment_index=0,
+        chunk_index=0,
+        source_file="doc.pdf",
+        text="Test text",
+        token_count=2,
+    )
+    assert chunk.content_hash == ""
+
+
+def test_chunk_model_dump_includes_hash() -> None:
+    """model_dump() includes content_hash for JSONL serialization."""
+    chunk = Chunk(
+        chunk_id="doc_p1_s0_c0",
+        document_id="doc",
+        page_number=1,
+        segment_index=0,
+        chunk_index=0,
+        source_file="doc.pdf",
+        text="Test text",
+        token_count=2,
+        content_hash="abc123",
+    )
+    data = chunk.model_dump()
+    assert "content_hash" in data
+    assert data["content_hash"] == "abc123"
+
+
+# ── token_chunker produces content_hash ─────────────────────────────────────
+
+
+def test_chunk_segment_produces_hash() -> None:
+    """chunk_segment() populates content_hash on each chunk."""
+    segment = StructuralSegment(
+        document_id="doc",
+        page_number=1,
+        segment_index=0,
+        section_title=None,
+        article_numbers=[],
+        source_file="doc.pdf",
+        text="Short text for hashing.",
+    )
+    chunks = chunk_segment(segment, chunk_size=500, chunk_overlap=50)
+    assert len(chunks) == 1
+    assert chunks[0].content_hash != ""
+    assert len(chunks[0].content_hash) == 64
+
+
+def test_chunk_segment_hash_matches_text() -> None:
+    """content_hash corresponds to the actual chunk text."""
+    segment = StructuralSegment(
+        document_id="doc",
+        page_number=1,
+        segment_index=0,
+        section_title=None,
+        article_numbers=[],
+        source_file="doc.pdf",
+        text="Exact text for verification.",
+    )
+    chunks = chunk_segment(segment, chunk_size=500, chunk_overlap=50)
+    expected_hash = compute_content_hash(chunks[0].text)
+    assert chunks[0].content_hash == expected_hash
+
+
+def test_chunk_segment_multi_chunk_all_have_hash() -> None:
+    """Multi-chunk segment: every chunk gets a content_hash."""
+    long_text = "word " * 600
+    segment = StructuralSegment(
+        document_id="doc",
+        page_number=1,
+        segment_index=0,
+        section_title=None,
+        article_numbers=[],
+        source_file="doc.pdf",
+        text=long_text,
+    )
+    chunks = chunk_segment(segment, chunk_size=500, chunk_overlap=50)
+    assert len(chunks) >= 2
+    for chunk in chunks:
+        assert chunk.content_hash != ""
+        assert chunk.content_hash == compute_content_hash(chunk.text)
+
+
+# ── Incremental classification logic ────────────────────────────────────────
+
+
+def _classify_chunks_pure(chunks, existing_hashes):
+    """Pure reimplementation of indexer._classify_chunks for testing without heavy imports."""
+    new, changed, unchanged = [], [], []
+    for chunk in chunks:
+        old_hash = existing_hashes.get(chunk.chunk_id)
+        if old_hash is None:
+            new.append(chunk)
+        elif old_hash != chunk.content_hash:
+            changed.append(chunk)
+        else:
+            unchanged.append(chunk)
+    return new, changed, unchanged
+
+
+def test_classify_all_new() -> None:
+    """When no existing hashes, all chunks are classified as new."""
+
+    chunks = [
+        Chunk(
+            chunk_id=f"doc_p1_s0_c{i}",
+            document_id="doc",
+            page_number=1,
+            segment_index=0,
+            chunk_index=i,
+            source_file="doc.pdf",
+            text=f"text {i}",
+            token_count=2,
+            content_hash=compute_content_hash(f"text {i}"),
+        )
+        for i in range(3)
+    ]
+    new, changed, unchanged = _classify_chunks_pure(chunks, {})
+    assert len(new) == 3
+    assert len(changed) == 0
+    assert len(unchanged) == 0
+
+
+def test_classify_all_unchanged() -> None:
+    """When all hashes match, all chunks are skipped."""
+    chunks = [
+        Chunk(
+            chunk_id="doc_p1_s0_c0",
+            document_id="doc",
+            page_number=1,
+            segment_index=0,
+            chunk_index=0,
+            source_file="doc.pdf",
+            text="same text",
+            token_count=2,
+            content_hash=compute_content_hash("same text"),
+        )
+    ]
+    existing = {"doc_p1_s0_c0": compute_content_hash("same text")}
+    new, changed, unchanged = _classify_chunks_pure(chunks, existing)
+    assert len(new) == 0
+    assert len(changed) == 0
+    assert len(unchanged) == 1
+
+
+def test_classify_changed() -> None:
+    """When hash differs, chunk is classified as changed."""
+    chunks = [
+        Chunk(
+            chunk_id="doc_p1_s0_c0",
+            document_id="doc",
+            page_number=1,
+            segment_index=0,
+            chunk_index=0,
+            source_file="doc.pdf",
+            text="new text",
+            token_count=2,
+            content_hash=compute_content_hash("new text"),
+        )
+    ]
+    existing = {"doc_p1_s0_c0": compute_content_hash("old text")}
+    new, changed, unchanged = _classify_chunks_pure(chunks, existing)
+    assert len(new) == 0
+    assert len(changed) == 1
+    assert len(unchanged) == 0
+
+
+def test_classify_mixed() -> None:
+    """Mixed scenario: some new, some changed, some unchanged."""
+    hash_a = compute_content_hash("text a")
+    hash_b_old = compute_content_hash("text b old")
+    hash_b_new = compute_content_hash("text b new")
+    hash_c = compute_content_hash("text c")
+
+    chunks = [
+        Chunk(
+            chunk_id="doc_p1_s0_c0",
+            document_id="doc",
+            page_number=1,
+            segment_index=0,
+            chunk_index=0,
+            source_file="doc.pdf",
+            text="text a",
+            token_count=2,
+            content_hash=hash_a,
+        ),
+        Chunk(
+            chunk_id="doc_p1_s0_c1",
+            document_id="doc",
+            page_number=1,
+            segment_index=0,
+            chunk_index=1,
+            source_file="doc.pdf",
+            text="text b new",
+            token_count=2,
+            content_hash=hash_b_new,
+        ),
+        Chunk(
+            chunk_id="doc_p1_s0_c2",
+            document_id="doc",
+            page_number=1,
+            segment_index=0,
+            chunk_index=2,
+            source_file="doc.pdf",
+            text="text c",
+            token_count=2,
+            content_hash=hash_c,
+        ),
+    ]
+    existing = {
+        # c0 unchanged
+        "doc_p1_s0_c0": hash_a,
+        # c1 changed
+        "doc_p1_s0_c1": hash_b_old,
+        # c2 not in existing → new
+    }
+    new, changed, unchanged = _classify_chunks_pure(chunks, existing)
+    assert len(new) == 1
+    assert new[0].chunk_id == "doc_p1_s0_c2"
+    assert len(changed) == 1
+    assert changed[0].chunk_id == "doc_p1_s0_c1"
+    assert len(unchanged) == 1
+    assert unchanged[0].chunk_id == "doc_p1_s0_c0"


### PR DESCRIPTION
## Summary

- **Incremental indexing**: chunks are classified as new/changed/unchanged via SHA-256 content hash — only new and changed chunks are re-embedded, skipping unchanged ones entirely
- **Embedding versioning**: each indexed vector now stores the `embedding_model` that produced it, enabling future model comparison and rollback
- **Ingestion tracing**: full OpenTelemetry spans (`indexing_pipeline`, `batch_embedding`, `weaviate_insert`, `fetch_existing_hashes`) visible in Phoenix alongside existing query-time traces
- **CI fix**: added `sentence-transformers`, `requests`, and `opentelemetry-api` to CI dependencies to resolve collection errors on 5 test files
- **README**: added CI/Python/License/Weaviate/OTel badges, new "Incremental Indexing" section with Notion article motivation, updated dataset format and roadmap

Motivated by practices described in [Two years of vector search at Notion](https://www.notion.com/pt/blog/two-years-of-vector-search-at-notion).

## Test plan

- [x] `pytest tests/test_content_hash.py -v` — 15 tests for hashing and classification
- [x] `pytest tests/ -m "not slow and not integration" -v` — full suite, no regressions
- [x] `python scripts/run_pipeline.py` — first run indexes all chunks
- [x] `python scripts/run_indexing.py` — second run skips all unchanged chunks
- [x] Phoenix shows `indexing_pipeline` spans with `chunks_new`, `chunks_skipped`, `embedding_time_ms` attributes
- [x] CI passes (lint + tests)
